### PR TITLE
Unify markdown rendering and build markdown-first protocol CMS

### DIFF
--- a/PROTOCOLS_SCHEMA_RESET.sql
+++ b/PROTOCOLS_SCHEMA_RESET.sql
@@ -1,0 +1,61 @@
+-- Supabase SQL script for a Markdown-only protocols CMS.
+-- Run this in the Supabase SQL editor.
+
+begin;
+
+-- UUID generation helper (needed for id default)
+create extension if not exists pgcrypto;
+
+-- 1) Ensure table exists with required baseline columns.
+create table if not exists public.protocols (
+  id uuid primary key default gen_random_uuid(),
+  title text not null,
+  content text not null default '',
+  discipline text not null default 'Algemeen',
+  updated_at timestamptz not null default now()
+);
+
+-- 2) Normalize schema to expected shape (safe if columns already exist).
+alter table public.protocols
+  add column if not exists title text,
+  add column if not exists content text,
+  add column if not exists discipline text,
+  add column if not exists updated_at timestamptz;
+
+alter table public.protocols
+  alter column title set not null,
+  alter column content set not null,
+  alter column discipline set not null,
+  alter column updated_at set not null;
+
+alter table public.protocols
+  alter column content set default '',
+  alter column discipline set default 'Algemeen',
+  alter column updated_at set default now();
+
+-- 3) Keep updated_at fresh on every update.
+create or replace function public.set_protocols_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_protocols_updated_at on public.protocols;
+create trigger trg_protocols_updated_at
+before update on public.protocols
+for each row
+execute function public.set_protocols_updated_at();
+
+-- 4) Delete existing rows that clearly contain HTML tags.
+-- This keeps Markdown rows and removes "HTML polluted" rows.
+delete from public.protocols
+where content ~* '<\\/?[a-z][^>]*>';
+
+-- Optional hard reset (use only if you want to wipe ALL rows):
+-- truncate table public.protocols;
+
+commit;

--- a/PROTOCOLS_SCHEMA_RESET.sql
+++ b/PROTOCOLS_SCHEMA_RESET.sql
@@ -22,6 +22,14 @@ alter table public.protocols
   add column if not exists discipline text,
   add column if not exists updated_at timestamptz;
 
+-- 2b) Backfill existing NULL/empty values before NOT NULL constraints.
+update public.protocols
+set
+  title = coalesce(nullif(trim(title), ''), 'Onbekend protocol'),
+  content = coalesce(content, ''),
+  discipline = coalesce(nullif(trim(discipline), ''), 'Algemeen'),
+  updated_at = coalesce(updated_at, now());
+
 alter table public.protocols
   alter column title set not null,
   alter column content set not null,

--- a/PROTOCOLS_SCHEMA_RESET.sql
+++ b/PROTOCOLS_SCHEMA_RESET.sql
@@ -58,4 +58,10 @@ where content ~* '<\\/?[a-z][^>]*>';
 -- Optional hard reset (use only if you want to wipe ALL rows):
 -- truncate table public.protocols;
 
+-- Optional discipline cleanup for legacy obstetrics labels:
+-- update public.protocols
+-- set discipline = 'Obstetrie-epidurale'
+-- where lower(trim(discipline)) in ('obstetrie', 'obstetrie epidurale', 'obstetrie_epidurale')
+--    or lower(trim(discipline)) like 'obstetrie%';
+
 commit;

--- a/client/src/components/MarkdownRenderer.tsx
+++ b/client/src/components/MarkdownRenderer.tsx
@@ -1,17 +1,13 @@
-import React, { useEffect, useRef } from "react";
+import React from "react";
 import ReactMarkdown from "react-markdown";
+import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
-import rehypeRaw from "rehype-raw";
-import Zoom from "react-medium-image-zoom";
-import "react-medium-image-zoom/dist/styles.css";
 import remarkMath from "remark-math";
 import rehypeKatex from "rehype-katex";
+import Zoom from "react-medium-image-zoom";
+import "react-medium-image-zoom/dist/styles.css";
 import "katex/dist/katex.min.css";
-// @ts-expect-error - KaTeX contrib doesn't have official types, but we need the JS
-import renderMathInElement from "katex/dist/contrib/auto-render";
-import parse, { domToReact, HTMLReactParserOptions, Element } from "html-react-parser";
 
-// Verbeterde flattenText voor TS compatibiliteit
 const flattenText = (node: any): string => {
   if (typeof node === "string") return node;
   if (Array.isArray(node)) return node.map(flattenText).join("");
@@ -21,18 +17,45 @@ const flattenText = (node: any): string => {
   return "";
 };
 
+const cleanCalloutTokens = (node: any): any => {
+  if (typeof node === "string") {
+    return node.replace(/\[!(TIP|INFO|WARNING|CAUTION)\]/gi, "").trimStart();
+  }
+
+  if (Array.isArray(node)) {
+    return node.map(cleanCalloutTokens);
+  }
+
+  if (React.isValidElement(node)) {
+    return React.cloneElement(node, {
+      ...node.props,
+      children: cleanCalloutTokens((node.props as any).children),
+    } as any);
+  }
+
+  return node;
+};
+
+const extractVideoUrl = (text: string): string | null => {
+  const shortcodeMatch = text.match(/\[VIDEO:(.*?)\]/i);
+  if (shortcodeMatch?.[1]) return shortcodeMatch[1].trim();
+
+  const videoProtocolMatch = text.match(/^video:\/\/(.+)$/i);
+  if (videoProtocolMatch?.[1]) return videoProtocolMatch[1].trim();
+
+  const videoPrefixMatch = text.match(/^video:\s*(.+)$/i);
+  if (videoPrefixMatch?.[1]) return videoPrefixMatch[1].trim();
+
+  return null;
+};
+
 const renderVideoBlock = (url: string) => {
   const trimmed = url.trim();
   if (!trimmed) return null;
+
   return (
-    <div className="my-8 w-full overflow-hidden rounded-3xl shadow-xl bg-black aspect-video border border-slate-100">
-      <video
-        controls
-        playsInline
-        preload="metadata"
-        className="w-full h-full object-contain"
-        src={trimmed}
-      >
+    <div className="my-8 w-full overflow-hidden rounded-3xl border border-slate-100 bg-black shadow-xl aspect-video">
+      <video controls playsInline preload="metadata" className="h-full w-full object-contain" src={trimmed}>
         <source src={trimmed} type="video/mp4" />
       </video>
     </div>
@@ -40,147 +63,78 @@ const renderVideoBlock = (url: string) => {
 };
 
 export function MarkdownRenderer({ content }: { content: string }) {
-  const htmlContainerRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (htmlContainerRef.current) {
-      renderMathInElement(htmlContainerRef.current, {
-        delimiters: [
-          { left: "$$", right: "$$", display: true },
-          { left: "$", right: "$", display: false },
-        ],
-        throwOnError: false,
-      });
-    }
-  }, [content]);
-
-  if (!content) return null;
-
-  const options: HTMLReactParserOptions = {
-    replace: (domNode) => {
-      if (!(domNode instanceof Element)) return;
-
-      if (domNode.name === "img") {
-        return (
-          <div className="my-8">
-            <Zoom>
-              <img
-                {...domNode.attribs}
-                className="rounded-3xl shadow-xl border border-slate-100 w-full h-auto"
-                alt={domNode.attribs.alt || ""}
-              />
-            </Zoom>
-          </div>
-        );
-      }
-
-      if (domNode.name === "blockquote") {
-        const childrenReact = domToReact(domNode.children as any);
-        const fullText = flattenText(childrenReact);
-        const isWarning = /WAARSCHUWING|LET OP|CAUTION/i.test(fullText);
-        const isInfo = /INFO|NOTE/i.test(fullText);
-        const config = isWarning
-          ? { styles: "border-red-500 bg-red-50", title: "⚠️ WAARSCHUWING", color: "text-red-600" }
-          : isInfo
-          ? { styles: "border-blue-500 bg-blue-50", title: "ℹ️ INFORMATIE", color: "text-blue-600" }
-          : { styles: "border-emerald-500 bg-emerald-50", title: "💡 TIP", color: "text-emerald-600" };
-
-        return (
-          <div className={`my-8 border-l-4 rounded-r-2xl p-6 ${config.styles}`}>
-            <div className={`text-[10px] font-black tracking-widest mb-2 ${config.color}`}>{config.title}</div>
-            <div className="text-slate-700 italic font-medium">{childrenReact}</div>
-          </div>
-        );
-      }
-
-      if (domNode.name === "video") {
-        const src = domNode.attribs.src || (domNode.children?.find((c: any) => c.name === "source") as any)?.attribs?.src;
-        return renderVideoBlock(src);
-      }
-    },
-  };
-
-  const isHtml = /<[a-z][\s\S]*>/i.test(content);
-
-  if (isHtml) {
-    return (
-      <div
-        ref={htmlContainerRef}
-        className="prose prose-slate max-w-none [hyphens:auto] break-words
-          prose-h2:text-[10px] prose-h2:font-black prose-h2:uppercase prose-h2:tracking-[0.2em] prose-h2:text-blue-600 prose-h2:mb-2 prose-h2:mt-8 prose-h2:border-b prose-h2:border-blue-100 prose-h2:pb-1
-          prose-a:text-blue-600 prose-a:font-bold prose-a:no-underline hover:prose-a:underline"
-      >
-        {parse(content, options)}
-      </div>
-    );
-  }
+  if (!content?.trim()) return null;
 
   return (
-    <ReactMarkdown
-      remarkPlugins={[remarkGfm, remarkMath]}
-      rehypePlugins={[rehypeRaw, rehypeKatex]}
-      components={{
-        // FIX: Gebruik any voor props om mismatch met ReactMarkdown types te voorkomen
-        blockquote: (props: any) => {
-          const { children } = props;
-          const fullText = flattenText(children);
-          const isWarning = /\[!(WARNING|CAUTION)\]/i.test(fullText);
-          const isInfo = /\[!INFO\]/i.test(fullText);
-          const config = isWarning
-            ? { styles: "border-red-500 bg-red-50", title: "⚠️ WAARSCHUWING", color: "text-red-600" }
-            : isInfo
-            ? { styles: "border-blue-500 bg-blue-50", title: "ℹ️ INFORMATIE", color: "text-blue-600" }
-            : { styles: "border-emerald-500 bg-emerald-50", title: "💡 TIP", color: "text-emerald-600" };
-
-          const cleanNode = (node: any): any => {
-            if (typeof node === "string") return node.replace(/\[!(TIP|INFO|WARNING|CAUTION)\]/gi, "").trim();
-            if (Array.isArray(node)) return node.map(cleanNode);
-            if (React.isValidElement(node)) {
-              return React.cloneElement(node, { 
-                children: cleanNode((node.props as any).children) 
-              } as any);
-            }
-            return node;
-          };
-
-          return (
-            <div className={`my-8 border-l-4 rounded-r-2xl p-6 ${config.styles}`}>
-              <div className={`text-[10px] font-black tracking-widest mb-2 ${config.color}`}>{config.title}</div>
-              <div className="text-slate-700 font-medium italic">{cleanNode(children)}</div>
-            </div>
-          );
-        },
-        img: (props: any) => {
-          const { node, ...rest } = props;
-          return (
-            <div className="my-8">
-              <Zoom>
-                <img {...rest} className="rounded-3xl shadow-xl border border-slate-100 w-full h-auto" />
-              </Zoom>
-            </div>
-          );
-        },
-        p: (props: any) => {
-          const { children } = props;
-          const text = flattenText(children);
-
-          // Shortcode detectie [VIDEO:url]
-          if (text.includes("[VIDEO:")) {
-            const videoUrl = text.match(/\[VIDEO:(.*?)\]/)?.[1];
-            if (videoUrl) return renderVideoBlock(videoUrl);
-          }
-
-          // video:// detectie
-          if (text.startsWith("video://")) {
-            const url = text.replace("video://", "").trim();
-            return renderVideoBlock(url);
-          }
-
-          return <div className="mb-4 last:mb-0 leading-relaxed text-slate-700">{parse(content, options)}</div>;
-        },
-      }}
+    <div
+      className="prose prose-slate max-w-none [hyphens:auto] break-words
+        prose-h2:text-[10px] prose-h2:font-black prose-h2:uppercase prose-h2:tracking-[0.2em] prose-h2:text-blue-600 prose-h2:mb-2 prose-h2:mt-8 prose-h2:border-b prose-h2:border-blue-100 prose-h2:pb-1
+        prose-a:text-blue-600 prose-a:font-bold prose-a:no-underline hover:prose-a:underline"
     >
-      {content}
-    </ReactMarkdown>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm, remarkBreaks, remarkMath]}
+        rehypePlugins={[rehypeKatex]}
+        components={{
+          blockquote: (props: any) => {
+            const { children } = props;
+            const fullText = flattenText(children);
+            const isWarning = /\[!(WARNING|CAUTION)\]/i.test(fullText);
+            const isInfo = /\[!INFO\]/i.test(fullText);
+            const isTip = /\[!TIP\]/i.test(fullText);
+
+            if (!isWarning && !isInfo && !isTip) {
+              return <blockquote className="my-8 border-l-4 border-slate-200 pl-6 text-slate-600">{children}</blockquote>;
+            }
+
+            const config = isWarning
+              ? { styles: "border-red-500 bg-red-50", title: "WAARSCHUWING", color: "text-red-600" }
+              : isInfo
+                ? { styles: "border-blue-500 bg-blue-50", title: "INFO", color: "text-blue-600" }
+                : { styles: "border-emerald-500 bg-emerald-50", title: "TIP", color: "text-emerald-600" };
+
+            return (
+              <div className={`my-4 rounded-r-3xl border-l-8 p-5 shadow-sm ${config.styles}`}>
+                <div className={`mb-1 text-[10px] font-black tracking-[0.2em] ${config.color}`}>{config.title}</div>
+                <div className="leading-snug font-normal text-slate-900 whitespace-pre-wrap [&_p]:m-0">
+                  {cleanCalloutTokens(children)}
+                </div>
+              </div>
+            );
+          },
+          img: (props: any) => {
+            const { alt, ...rest } = props;
+            const isSmall = typeof alt === "string" && alt.includes("size-small");
+            return (
+              <div className={isSmall ? "my-4" : "my-8"}>
+                <Zoom>
+                  <img
+                    {...rest}
+                    alt={alt}
+                    className={
+                      isSmall
+                        ? "w-auto max-h-32 rounded-lg border border-slate-200"
+                        : "h-auto w-full rounded-2xl border border-slate-100 shadow-lg"
+                    }
+                  />
+                </Zoom>
+              </div>
+            );
+          },
+          p: (props: any) => {
+            const { children } = props;
+            const text = flattenText(children).trim();
+            const videoUrl = extractVideoUrl(text);
+
+            if (videoUrl) {
+              return renderVideoBlock(videoUrl);
+            }
+
+            return <p className="mb-4 last:mb-0 leading-relaxed text-slate-700">{children}</p>;
+          },
+        }}
+      >
+        {content}
+      </ReactMarkdown>
+    </div>
   );
 }

--- a/client/src/pages/admin-editor.tsx
+++ b/client/src/pages/admin-editor.tsx
@@ -8,6 +8,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useToast } from "@/hooks/use-toast";
 import { Loader2, Save, ArrowLeft, Video, ImageIcon, HelpCircle, ExternalLink } from "lucide-react";
+import { MarkdownRenderer } from "@/components/MarkdownRenderer";
 
 
 import ReactQuill from "react-quill-new";
@@ -57,7 +58,7 @@ export default function AdminEditor() {
   const search = useSearch();
   const queryParams = new URLSearchParams(search);
   const editId   = queryParams.get("id");
-  const editType = queryParams.get("type") || "pocus";
+  const editType = queryParams.get("type") || "protocols";
 
   const { toast } = useToast();
   const [loading,    setLoading]    = useState(false);
@@ -198,26 +199,43 @@ export default function AdminEditor() {
     if (!title) return toast({ title: "Titel verplicht", variant: "destructive" });
     setLoading(true);
     try {
-      const payload: Record<string, unknown> = { title };
+      let error: any = null;
 
-      if (isMultiTab(type)) {
-        const cfg = TAB_CONFIG[type];
-        payload[cfg[0].field] = tab1;
-        payload[cfg[1].field] = tab2;
-        payload[cfg[2].field] = tab3;
-      } else if (type === "journal_club") {
-        payload.content    = content;
-        payload.disciplines = discipline ? [discipline] : [];
-        if (pubmedId.trim()) payload.pubmed_id = pubmedId.trim();
+      if (type === "protocols") {
+        const protocolPayload = {
+          title,
+          discipline,
+          content,
+        };
+
+        const result = editId
+          ? await supabase.from("protocols").update(protocolPayload).eq("id", editId)
+          : await supabase.from("protocols").insert([protocolPayload]);
+
+        error = result.error;
       } else {
-        // protocols
-        payload.content    = content;
-        payload.discipline = discipline;
-      }
+        const payload: Record<string, unknown> = { title };
 
-      const { error } = editId
-        ? await supabase.from(type).update(payload).eq("id", editId)
-        : await supabase.from(type).insert([payload]);
+        if (isMultiTab(type)) {
+          const cfg = TAB_CONFIG[type];
+          payload[cfg[0].field] = tab1;
+          payload[cfg[1].field] = tab2;
+          payload[cfg[2].field] = tab3;
+        } else if (type === "journal_club") {
+          payload.content = content;
+          payload.disciplines = discipline ? [discipline] : [];
+          if (pubmedId.trim()) payload.pubmed_id = pubmedId.trim();
+        } else {
+          payload.content = content;
+          payload.discipline = discipline;
+        }
+
+        const result = editId
+          ? await supabase.from(type).update(payload).eq("id", editId)
+          : await supabase.from(type).insert([payload]);
+
+        error = result.error;
+      }
 
       if (error) throw error;
       toast({ title: "Succesvol opgeslagen!" });
@@ -381,17 +399,28 @@ export default function AdminEditor() {
                     />
                   </div>
 
-                  <UploadBar />
+                  <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+                    <div className="space-y-2">
+                      <label className="text-[10px] font-black uppercase text-slate-400 ml-1">
+                        Markdown (ruw)
+                      </label>
+                      <textarea
+                        value={content}
+                        onChange={(e) => setContent(e.target.value)}
+                        placeholder={"# Titel\n\nSchrijf hier je protocol in pure Markdown..."}
+                        spellCheck={false}
+                        className="h-[420px] w-full resize-y rounded-2xl border border-slate-200 bg-white p-4 font-mono text-sm leading-relaxed text-slate-900 focus:outline-none focus:ring-2 focus:ring-teal-500"
+                      />
+                    </div>
 
-                  <div className="min-h-[400px]">
-                    <QuillEditor
-                      ref={genericContentRef}
-                      value={content}
-                      onChange={(val: string) => setContent(stripBase64Images(val))}
-                      className="h-[350px]"
-                      theme="snow"
-                      modules={QUILL_MODULES}
-                    />
+                    <div className="space-y-2">
+                      <label className="text-[10px] font-black uppercase text-slate-400 ml-1">
+                        Live preview
+                      </label>
+                      <div className="h-[420px] overflow-y-auto rounded-2xl border border-slate-200 bg-white p-4">
+                        <MarkdownRenderer content={content} />
+                      </div>
+                    </div>
                   </div>
                 </>
               )}

--- a/client/src/pages/admin-editor.tsx
+++ b/client/src/pages/admin-editor.tsx
@@ -7,7 +7,7 @@ import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useToast } from "@/hooks/use-toast";
-import { Loader2, Save, ArrowLeft, Video, ImageIcon, HelpCircle, ExternalLink } from "lucide-react";
+import { Loader2, Save, ArrowLeft, Video, ImageIcon, HelpCircle, ExternalLink, CloudDownload } from "lucide-react";
 import { MarkdownRenderer } from "@/components/MarkdownRenderer";
 
 
@@ -52,6 +52,47 @@ const QUILL_MODULES = {
 const stripBase64Images = (html: string): string =>
   html.replace(/<img[^>]+src="data:[^">]+"[^>]*>/gi, "");
 
+const localProtocolFiles = import.meta.glob("../content/protocols/**/*.md", { query: "raw", eager: true });
+
+const parseFrontmatter = (rawMarkdown: string): { frontmatter: Record<string, string>; body: string } => {
+  const frontmatterMatch = rawMarkdown.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/);
+  if (!frontmatterMatch) {
+    return { frontmatter: {}, body: rawMarkdown };
+  }
+
+  const frontmatterRaw = frontmatterMatch[1];
+  const body = rawMarkdown.slice(frontmatterMatch[0].length);
+  const frontmatter: Record<string, string> = {};
+
+  for (const line of frontmatterRaw.split(/\r?\n/)) {
+    const separatorIndex = line.indexOf(":");
+    if (separatorIndex < 0) continue;
+
+    const key = line.slice(0, separatorIndex).trim().toLowerCase();
+    if (!key) continue;
+
+    const value = line
+      .slice(separatorIndex + 1)
+      .trim()
+      .replace(/^["']|["']$/g, "");
+
+    frontmatter[key] = value;
+  }
+
+  return { frontmatter, body };
+};
+
+const inferDisciplineFromProtocolPath = (path: string): string => {
+  const pathParts = path.split("/");
+  const rawDiscipline = pathParts[pathParts.length - 2] || "algemeen";
+  if (rawDiscipline.toLowerCase() === "protocols") return "Algemeen";
+
+  return rawDiscipline
+    .split("-")
+    .map((part) => (part ? `${part.charAt(0).toUpperCase()}${part.slice(1)}` : part))
+    .join("-");
+};
+
 // ─── Component ─────────────────────────────────────────────────────────────────
 export default function AdminEditor() {
   const [, setLocation] = useLocation();
@@ -59,6 +100,7 @@ export default function AdminEditor() {
   const queryParams = new URLSearchParams(search);
   const editId   = queryParams.get("id");
   const editType = queryParams.get("type") || "protocols";
+  const migrateSlug = queryParams.get("migrate");
 
   const { toast } = useToast();
   const [loading,    setLoading]    = useState(false);
@@ -70,12 +112,36 @@ export default function AdminEditor() {
   const [tab1, setTab1] = useState("");
   const [tab2, setTab2] = useState("");
   const [tab3, setTab3] = useState("");
+  const [isMigratingProtocol, setIsMigratingProtocol] = useState(false);
   const [activeTab, setActiveTab] = useState<"tab1" | "tab2" | "tab3">("tab1");
 
   const tabRef1          = useRef<any>(null);
   const tabRef2          = useRef<any>(null);
   const tabRef3          = useRef<any>(null);
   const genericContentRef = useRef<any>(null);
+
+  const protocolDraftToMigrate = React.useMemo(() => {
+    if (type !== "protocols" || !migrateSlug) return null;
+
+    const fileKey = Object.keys(localProtocolFiles).find((key) =>
+      key.toLowerCase().endsWith(`/${migrateSlug.toLowerCase()}.md`)
+    );
+
+    if (!fileKey) return null;
+
+    const fileData = localProtocolFiles[fileKey] as any;
+    const rawMarkdown = String(fileData?.default || fileData || "");
+    const { frontmatter, body } = parseFrontmatter(rawMarkdown);
+    const titleFromFrontmatter = frontmatter.title;
+    const disciplineFromFrontmatter = frontmatter.discipline || inferDisciplineFromProtocolPath(fileKey);
+
+    return {
+      slug: migrateSlug,
+      title: titleFromFrontmatter || migrateSlug.replace(/-/g, " "),
+      discipline: disciplineFromFrontmatter,
+      content: body,
+    };
+  }, [migrateSlug, type]);
 
   // ─── Load existing record ──────────────────────────────────────────────────
   useEffect(() => {
@@ -101,6 +167,13 @@ export default function AdminEditor() {
     };
     fetchData();
   }, [editId, type]);
+
+  useEffect(() => {
+    if (editId || type !== "protocols" || !protocolDraftToMigrate) return;
+    setTitle(protocolDraftToMigrate.title);
+    setDiscipline(protocolDraftToMigrate.discipline);
+    setContent(protocolDraftToMigrate.content);
+  }, [editId, protocolDraftToMigrate, type]);
 
   // ─── Ref helper ───────────────────────────────────────────────────────────
   const getActiveRef = () => {
@@ -247,6 +320,32 @@ export default function AdminEditor() {
     }
   };
 
+  const handleMigrateProtocolFile = async () => {
+    if (!protocolDraftToMigrate) {
+      toast({ title: "Bestand niet gevonden", description: "Controleer de migrate slug.", variant: "destructive" });
+      return;
+    }
+
+    setIsMigratingProtocol(true);
+    try {
+      const payload = {
+        title: protocolDraftToMigrate.title,
+        discipline: protocolDraftToMigrate.discipline,
+        content: protocolDraftToMigrate.content,
+      };
+
+      const { data, error } = await supabase.from("protocols").insert([payload]).select("id").single();
+      if (error) throw error;
+
+      toast({ title: "Migratie geslaagd", description: `${protocolDraftToMigrate.slug}.md staat nu in Supabase.` });
+      setLocation(`/protocols/${data.id}`);
+    } catch (err: any) {
+      toast({ title: "Migratie mislukt", description: err.message, variant: "destructive" });
+    } finally {
+      setIsMigratingProtocol(false);
+    }
+  };
+
   // ─── Upload toolbar (shared) ───────────────────────────────────────────────
   const UploadBar = () => (
     <div className="flex gap-2 p-2 bg-slate-100 rounded-2xl">
@@ -375,6 +474,41 @@ export default function AdminEditor() {
               {/* ── PROTOCOLS ───────────────────────────────────────────────── */}
               {type === "protocols" && (
                 <>
+                  {migrateSlug && (
+                    <div className="rounded-2xl border border-amber-200 bg-amber-50 p-4 space-y-3">
+                      <div className="text-[10px] font-black uppercase tracking-widest text-amber-700">
+                        Lokale migratie
+                      </div>
+                      {protocolDraftToMigrate ? (
+                        <>
+                          <p className="text-xs text-amber-900">
+                            Bestand <span className="font-bold">{protocolDraftToMigrate.slug}.md</span> is geladen via
+                            {" "}
+                            <code>import.meta.glob</code>. Klik hieronder om frontmatter + markdown body direct naar
+                            Supabase te inserten.
+                          </p>
+                          <Button
+                            type="button"
+                            onClick={handleMigrateProtocolFile}
+                            disabled={isMigratingProtocol}
+                            className="bg-amber-600 hover:bg-amber-700 text-white rounded-xl font-bold"
+                          >
+                            {isMigratingProtocol ? (
+                              <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                            ) : (
+                              <CloudDownload className="h-4 w-4 mr-2" />
+                            )}
+                            MIGREER LOKAAL BESTAND
+                          </Button>
+                        </>
+                      ) : (
+                        <p className="text-xs text-red-700">
+                          Geen lokaal protocolbestand gevonden voor slug: <b>{migrateSlug}</b>.
+                        </p>
+                      )}
+                    </div>
+                  )}
+
                   <div className="space-y-2">
                     <label className="text-[10px] font-black uppercase text-slate-400 ml-1">Discipline</label>
                     <Select value={discipline} onValueChange={setDiscipline}>

--- a/client/src/pages/admin-editor.tsx
+++ b/client/src/pages/admin-editor.tsx
@@ -104,6 +104,40 @@ const inferDisciplineFromProtocolPath = (path: string): string => {
 
 type TextSetter = React.Dispatch<React.SetStateAction<string>>;
 
+function MarkdownSplitPane({
+  value,
+  onChange,
+  textareaRef,
+  placeholder,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  textareaRef: React.RefObject<HTMLTextAreaElement>;
+  placeholder: string;
+}) {
+  return (
+    <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+      <div className="space-y-2">
+        <label className="ml-1 text-[10px] font-black uppercase text-slate-400">Markdown (ruw)</label>
+        <textarea
+          ref={textareaRef}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder}
+          spellCheck={false}
+          className="h-[420px] w-full resize-y rounded-2xl border border-slate-200 bg-white p-4 font-mono text-sm leading-relaxed text-slate-900 focus:outline-none focus:ring-2 focus:ring-teal-500"
+        />
+      </div>
+      <div className="space-y-2">
+        <label className="ml-1 text-[10px] font-black uppercase text-slate-400">Live preview</label>
+        <div className="h-[420px] overflow-y-auto rounded-2xl border border-slate-200 bg-white p-4">
+          <MarkdownRenderer content={value} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export default function AdminEditor() {
   const [, setLocation] = useLocation();
   const search = useSearch();
@@ -385,38 +419,6 @@ export default function AdminEditor() {
           <input type="file" accept="application/pdf" className="hidden" onChange={(e) => handleFileUpload(e, "pdf")} />
         </label>
       )}
-    </div>
-  );
-
-  const MarkdownSplitPane = ({
-    value,
-    onChange,
-    textareaRef,
-    placeholder,
-  }: {
-    value: string;
-    onChange: (value: string) => void;
-    textareaRef: React.RefObject<HTMLTextAreaElement>;
-    placeholder: string;
-  }) => (
-    <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-      <div className="space-y-2">
-        <label className="ml-1 text-[10px] font-black uppercase text-slate-400">Markdown (ruw)</label>
-        <textarea
-          ref={textareaRef}
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          placeholder={placeholder}
-          spellCheck={false}
-          className="h-[420px] w-full resize-y rounded-2xl border border-slate-200 bg-white p-4 font-mono text-sm leading-relaxed text-slate-900 focus:outline-none focus:ring-2 focus:ring-teal-500"
-        />
-      </div>
-      <div className="space-y-2">
-        <label className="ml-1 text-[10px] font-black uppercase text-slate-400">Live preview</label>
-        <div className="h-[420px] overflow-y-auto rounded-2xl border border-slate-200 bg-white p-4">
-          <MarkdownRenderer content={value} />
-        </div>
-      </div>
     </div>
   );
 

--- a/client/src/pages/admin-editor.tsx
+++ b/client/src/pages/admin-editor.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { supabase } from "@/lib/supabase";
 import { useLocation, useSearch } from "wouter";
 import { Card, CardContent } from "@/components/ui/card";
@@ -7,35 +7,47 @@ import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useToast } from "@/hooks/use-toast";
-import { Loader2, Save, ArrowLeft, Video, ImageIcon, HelpCircle, ExternalLink, CloudDownload } from "lucide-react";
+import {
+  ArrowLeft,
+  CloudDownload,
+  ExternalLink,
+  FileText,
+  HelpCircle,
+  ImageIcon,
+  Loader2,
+  Save,
+  Video,
+} from "lucide-react";
 import { MarkdownRenderer } from "@/components/MarkdownRenderer";
-
-
 import ReactQuill from "react-quill-new";
 import "react-quill-new/dist/quill.snow.css";
 
 const QuillEditor = ReactQuill as any;
 
-// ─── Tab-configuratie per module ───────────────────────────────────────────────
 const TAB_CONFIG: Record<string, { label: string; field: string }[]> = {
   pocus: [
     { label: "Indicaties", field: "content_indicaties" },
-    { label: "Techniek",   field: "content_techniek" },
+    { label: "Techniek", field: "content_techniek" },
     { label: "Interpretatie", field: "content_interpretatie" },
   ],
   blocks: [
-    { label: "Algemeen",  field: "content_general" },
-    { label: "Anatomie",  field: "content_anatomy" },
-    { label: "Techniek",  field: "content_technique" },
+    { label: "Samenvatting", field: "content_general" },
+    { label: "Anatomie", field: "content_anatomy" },
+    { label: "Techniek", field: "content_technique" },
   ],
 };
 
-const isMultiTab = (t: string) => t === "pocus" || t === "blocks";
-
 const PROTOCOL_DISCIPLINES = [
-  "Abdominale", "Buitendiensten", "Neurochirurgie", "NKO",
-  "Obstetrie-epidurale", "Orthopedie", "Pijnkliniek",
-  "Reanimatie", "Thorax-vaat", "Algemeen",
+  "Abdominale",
+  "Buitendiensten",
+  "Neurochirurgie",
+  "NKO",
+  "Obstetrie-epidurale",
+  "Orthopedie",
+  "Pijnkliniek",
+  "Reanimatie",
+  "Thorax-vaat",
+  "Algemeen",
 ];
 
 const JOURNAL_DISCIPLINES = ["Anesthesie", "Intensieve", "Urgentie", "Pijn"];
@@ -49,16 +61,13 @@ const QUILL_MODULES = {
   ],
 };
 
-const stripBase64Images = (html: string): string =>
-  html.replace(/<img[^>]+src="data:[^">]+"[^>]*>/gi, "");
+const stripBase64Images = (html: string): string => html.replace(/<img[^>]+src="data:[^">]+"[^>]*>/gi, "");
 
 const localProtocolFiles = import.meta.glob("../content/protocols/**/*.md", { query: "raw", eager: true });
 
 const parseFrontmatter = (rawMarkdown: string): { frontmatter: Record<string, string>; body: string } => {
   const frontmatterMatch = rawMarkdown.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/);
-  if (!frontmatterMatch) {
-    return { frontmatter: {}, body: rawMarkdown };
-  }
+  if (!frontmatterMatch) return { frontmatter: {}, body: rawMarkdown };
 
   const frontmatterRaw = frontmatterMatch[1];
   const body = rawMarkdown.slice(frontmatterMatch[0].length);
@@ -93,78 +102,86 @@ const inferDisciplineFromProtocolPath = (path: string): string => {
     .join("-");
 };
 
-// ─── Component ─────────────────────────────────────────────────────────────────
+type TextSetter = React.Dispatch<React.SetStateAction<string>>;
+
 export default function AdminEditor() {
   const [, setLocation] = useLocation();
   const search = useSearch();
   const queryParams = new URLSearchParams(search);
-  const editId   = queryParams.get("id");
+  const editId = queryParams.get("id");
   const editType = queryParams.get("type") || "protocols";
   const migrateSlug = queryParams.get("migrate");
 
   const { toast } = useToast();
-  const [loading,    setLoading]    = useState(false);
-  const [type,       setType]       = useState(editType);
-  const [title,      setTitle]      = useState("");
+  const [loading, setLoading] = useState(false);
+  const [type, setType] = useState(editType);
+  const [title, setTitle] = useState("");
   const [discipline, setDiscipline] = useState("");
-  const [pubmedId,   setPubmedId]   = useState("");
-  const [content,    setContent]    = useState("");
+  const [pubmedId, setPubmedId] = useState("");
+  const [content, setContent] = useState("");
   const [tab1, setTab1] = useState("");
   const [tab2, setTab2] = useState("");
   const [tab3, setTab3] = useState("");
   const [isMigratingProtocol, setIsMigratingProtocol] = useState(false);
   const [activeTab, setActiveTab] = useState<"tab1" | "tab2" | "tab3">("tab1");
 
-  const tabRef1          = useRef<any>(null);
-  const tabRef2          = useRef<any>(null);
-  const tabRef3          = useRef<any>(null);
-  const genericContentRef = useRef<any>(null);
+  const pocusRef1 = useRef<any>(null);
+  const pocusRef2 = useRef<any>(null);
+  const pocusRef3 = useRef<any>(null);
+  const singleTextareaRef = useRef<HTMLTextAreaElement>(null);
+  const blockTextareaRef1 = useRef<HTMLTextAreaElement>(null);
+  const blockTextareaRef2 = useRef<HTMLTextAreaElement>(null);
+  const blockTextareaRef3 = useRef<HTMLTextAreaElement>(null);
 
-  const protocolDraftToMigrate = React.useMemo(() => {
+  const protocolDraftToMigrate = useMemo(() => {
     if (type !== "protocols" || !migrateSlug) return null;
 
     const fileKey = Object.keys(localProtocolFiles).find((key) =>
       key.toLowerCase().endsWith(`/${migrateSlug.toLowerCase()}.md`)
     );
-
     if (!fileKey) return null;
 
     const fileData = localProtocolFiles[fileKey] as any;
     const rawMarkdown = String(fileData?.default || fileData || "");
     const { frontmatter, body } = parseFrontmatter(rawMarkdown);
-    const titleFromFrontmatter = frontmatter.title;
-    const disciplineFromFrontmatter = frontmatter.discipline || inferDisciplineFromProtocolPath(fileKey);
 
     return {
       slug: migrateSlug,
-      title: titleFromFrontmatter || migrateSlug.replace(/-/g, " "),
-      discipline: disciplineFromFrontmatter,
+      title: frontmatter.title || migrateSlug.replace(/-/g, " "),
+      discipline: frontmatter.discipline || inferDisciplineFromProtocolPath(fileKey),
       content: body,
     };
   }, [migrateSlug, type]);
 
-  // ─── Load existing record ──────────────────────────────────────────────────
   useEffect(() => {
     if (!editId) return;
+
     const fetchData = async () => {
       const { data, error } = await supabase.from(type).select("*").eq("id", editId).single();
       if (!data || error) return;
+
       setTitle(data.title || "");
-      if (isMultiTab(type)) {
+
+      if (type === "pocus" || type === "blocks") {
         const cfg = TAB_CONFIG[type];
         setTab1(data[cfg[0].field] || "");
         setTab2(data[cfg[1].field] || "");
         setTab3(data[cfg[2].field] || "");
-      } else if (type === "journal_club") {
-        setContent(data.content || "");
-        const rawDisc = data.disciplines;
-        setDiscipline(Array.isArray(rawDisc) ? (rawDisc[0] || "") : (rawDisc || ""));
-        setPubmedId(data.pubmed_id || "");
-      } else {
-        setContent(data.content || "");
-        setDiscipline(data.discipline || "");
+        return;
       }
+
+      if (type === "journal_club") {
+        setContent(data.content || "");
+        const rawDisciplines = data.disciplines;
+        setDiscipline(Array.isArray(rawDisciplines) ? (rawDisciplines[0] || "") : (rawDisciplines || ""));
+        setPubmedId(data.pubmed_id || "");
+        return;
+      }
+
+      setContent(data.content || "");
+      setDiscipline(data.discipline || "");
     };
+
     fetchData();
   }, [editId, type]);
 
@@ -175,89 +192,93 @@ export default function AdminEditor() {
     setContent(protocolDraftToMigrate.content);
   }, [editId, protocolDraftToMigrate, type]);
 
-  // ─── Ref helper ───────────────────────────────────────────────────────────
-  const getActiveRef = () => {
-    if (!isMultiTab(type)) return genericContentRef;
-    if (activeTab === "tab1") return tabRef1;
-    if (activeTab === "tab2") return tabRef2;
-    return tabRef3;
-  };
-
-  const getActiveSetter = () => {
-    if (!isMultiTab(type)) return setContent;
+  const getActiveSetter = (): TextSetter => {
+    if (type === "protocols" || type === "journal_club") return setContent;
     if (activeTab === "tab1") return setTab1;
     if (activeTab === "tab2") return setTab2;
     return setTab3;
   };
 
-  // ─── Insert video shortcode at cursor position ─────────────────────────────
-  const insertVideoAtCursor = (editorRef: React.RefObject<any>, shortcode: string): boolean => {
-    const instance = editorRef.current;
-    if (!instance) return false;
-    const quill = instance.getEditor ? instance.getEditor() : instance;
-    if (!quill) return false;
-    quill.focus?.();
-    const range = quill.getSelection() || quill.getSelection(true) || null;
-    const index = range ? range.index : quill.getLength();
-    quill.insertText(index, shortcode, "user");
-    quill.insertText(index + shortcode.length, "\n", "user");
-    quill.setSelection(index + shortcode.length + 1, 0, "user");
+  const getActiveTextareaRef = (): React.RefObject<HTMLTextAreaElement> | null => {
+    if (type === "protocols" || type === "journal_club") return singleTextareaRef;
+    if (type !== "blocks") return null;
+    if (activeTab === "tab1") return blockTextareaRef1;
+    if (activeTab === "tab2") return blockTextareaRef2;
+    return blockTextareaRef3;
+  };
+
+  const getActivePocusRef = (): React.RefObject<any> | null => {
+    if (type !== "pocus") return null;
+    if (activeTab === "tab1") return pocusRef1;
+    if (activeTab === "tab2") return pocusRef2;
+    return pocusRef3;
+  };
+
+  const insertTextAtCursorInTextarea = (
+    ref: React.RefObject<HTMLTextAreaElement>,
+    valueToInsert: string,
+    setter: TextSetter
+  ): boolean => {
+    const textarea = ref.current;
+    if (!textarea) return false;
+
+    const start = textarea.selectionStart ?? textarea.value.length;
+    const end = textarea.selectionEnd ?? textarea.value.length;
+
+    setter((prev) => `${prev.slice(0, start)}${valueToInsert}${prev.slice(end)}`);
+    requestAnimationFrame(() => {
+      if (!ref.current) return;
+      const cursor = start + valueToInsert.length;
+      ref.current.focus();
+      ref.current.setSelectionRange(cursor, cursor);
+    });
     return true;
   };
 
-  // ─── Insert HTML (img/pdf) at cursor position ──────────────────────────────
-  const insertHtmlAtCursor = (editorRef: React.RefObject<any>, html: string): boolean => {
-    const instance = editorRef.current;
+  const insertTextAtCursorInQuill = (ref: React.RefObject<any>, valueToInsert: string): boolean => {
+    const instance = ref.current;
     if (!instance) return false;
     const quill = instance.getEditor ? instance.getEditor() : instance;
     if (!quill) return false;
+
     quill.focus?.();
     const range = quill.getSelection() || quill.getSelection(true) || null;
     const index = range ? range.index : quill.getLength();
-    quill.clipboard.dangerouslyPasteHTML(index, html);
+    quill.insertText(index, valueToInsert, "user");
+    quill.setSelection(index + valueToInsert.length, 0, "user");
     return true;
   };
 
-  // ─── File upload ──────────────────────────────────────────────────────────
-  const handleFileUpload = async (
-    e: React.ChangeEvent<HTMLInputElement>,
-    fileType: "img" | "video" | "pdf"
-  ) => {
+  const buildUploadSnippet = (fileType: "img" | "video" | "pdf", publicUrl: string, fileName: string): string => {
+    if (fileType === "video") return `\n[VIDEO:${publicUrl}]\n`;
+    if (fileType === "img") return `\n![${fileName.replace(/\.[^.]+$/, "") || "afbeelding"}](${publicUrl})\n`;
+    return `\n[📄 ${fileName}](${publicUrl})\n`;
+  };
+
+  const handleFileUpload = async (e: React.ChangeEvent<HTMLInputElement>, fileType: "img" | "video" | "pdf") => {
     const file = e.target.files?.[0];
     if (!file) return;
-    // Reset input so the same file can be re-selected
     e.target.value = "";
+
     setLoading(true);
     try {
       const filePath = `${type}/${Date.now()}_${file.name}`;
-      const { error: uploadError } = await supabase.storage
-        .from("media")
-        .upload(filePath, file);
+      const { error: uploadError } = await supabase.storage.from("media").upload(filePath, file);
       if (uploadError) throw uploadError;
 
-      const { data: { publicUrl } } = supabase.storage
-        .from("media")
-        .getPublicUrl(filePath);
+      const {
+        data: { publicUrl },
+      } = supabase.storage.from("media").getPublicUrl(filePath);
 
-      const ref     = getActiveRef();
-      const setter  = getActiveSetter();
+      const setter = getActiveSetter();
+      const textareaRef = getActiveTextareaRef();
+      const quillRef = getActivePocusRef();
+      const snippet = buildUploadSnippet(fileType, publicUrl, file.name);
 
-      if (fileType === "video") {
-        const shortcode = `[VIDEO:${publicUrl}]`;
-        if (!insertVideoAtCursor(ref, shortcode)) {
-          setter((prev: string) => prev + shortcode + "\n");
-        }
-      } else if (fileType === "img") {
-        const html = `<img src="${publicUrl}" alt="afbeelding" />`;
-        if (!insertHtmlAtCursor(ref, html)) {
-          setter((prev: string) => prev + html);
-        }
-      } else {
-        const html = `<a href="${publicUrl}" target="_blank" rel="noopener noreferrer" style="color:#0284c7;font-weight:bold;text-decoration:underline;">📄 ${file.name}</a>`;
-        if (!insertHtmlAtCursor(ref, html)) {
-          setter((prev: string) => prev + html);
-        }
-      }
+      let inserted = false;
+      if (textareaRef) inserted = insertTextAtCursorInTextarea(textareaRef, snippet, setter);
+      if (!inserted && quillRef) inserted = insertTextAtCursorInQuill(quillRef, snippet);
+      if (!inserted) setter((prev) => `${prev}${snippet}`);
 
       toast({ title: "Upload geslaagd" });
     } catch (err: any) {
@@ -267,46 +288,48 @@ export default function AdminEditor() {
     }
   };
 
-  // ─── Save ─────────────────────────────────────────────────────────────────
   const handleSave = async () => {
-    if (!title) return toast({ title: "Titel verplicht", variant: "destructive" });
+    if (!title.trim()) {
+      toast({ title: "Titel verplicht", variant: "destructive" });
+      return;
+    }
+
     setLoading(true);
     try {
       let error: any = null;
 
       if (type === "protocols") {
-        const protocolPayload = {
-          title,
-          discipline,
+        const payload = {
+          title: title.trim(),
+          discipline: discipline || "Algemeen",
           content,
         };
-
         const result = editId
-          ? await supabase.from("protocols").update(protocolPayload).eq("id", editId)
-          : await supabase.from("protocols").insert([protocolPayload]);
-
+          ? await supabase.from("protocols").update(payload).eq("id", editId)
+          : await supabase.from("protocols").insert([payload]);
         error = result.error;
-      } else {
-        const payload: Record<string, unknown> = { title };
-
-        if (isMultiTab(type)) {
-          const cfg = TAB_CONFIG[type];
-          payload[cfg[0].field] = tab1;
-          payload[cfg[1].field] = tab2;
-          payload[cfg[2].field] = tab3;
-        } else if (type === "journal_club") {
-          payload.content = content;
-          payload.disciplines = discipline ? [discipline] : [];
-          if (pubmedId.trim()) payload.pubmed_id = pubmedId.trim();
-        } else {
-          payload.content = content;
-          payload.discipline = discipline;
-        }
-
+      } else if (type === "journal_club") {
+        const payload: Record<string, unknown> = {
+          title: title.trim(),
+          content,
+          disciplines: discipline ? [discipline] : [],
+        };
+        if (pubmedId.trim()) payload.pubmed_id = pubmedId.trim();
+        const result = editId
+          ? await supabase.from("journal_club").update(payload).eq("id", editId)
+          : await supabase.from("journal_club").insert([payload]);
+        error = result.error;
+      } else if (type === "blocks" || type === "pocus") {
+        const cfg = TAB_CONFIG[type];
+        const payload = {
+          title: title.trim(),
+          [cfg[0].field]: tab1,
+          [cfg[1].field]: tab2,
+          [cfg[2].field]: tab3,
+        };
         const result = editId
           ? await supabase.from(type).update(payload).eq("id", editId)
           : await supabase.from(type).insert([payload]);
-
         error = result.error;
       }
 
@@ -346,49 +369,78 @@ export default function AdminEditor() {
     }
   };
 
-  // ─── Upload toolbar (shared) ───────────────────────────────────────────────
-  const UploadBar = () => (
-    <div className="flex gap-2 p-2 bg-slate-100 rounded-2xl">
-      <label className="flex-1 flex items-center justify-center gap-2 py-3 bg-white rounded-xl shadow-sm cursor-pointer hover:bg-slate-50 transition-colors text-[10px] font-black uppercase tracking-widest">
+  const UploadBar = ({ showPdf = false }: { showPdf?: boolean }) => (
+    <div className="flex flex-wrap gap-2 rounded-2xl bg-slate-100 p-2">
+      <label className="flex flex-1 min-w-[140px] items-center justify-center gap-2 rounded-xl bg-white py-3 text-[10px] font-black uppercase tracking-widest shadow-sm cursor-pointer hover:bg-slate-50 transition-colors">
         <Video className="h-4 w-4 text-teal-600" /> Video
         <input type="file" accept="video/*" className="hidden" onChange={(e) => handleFileUpload(e, "video")} />
       </label>
-      <label className="flex-1 flex items-center justify-center gap-2 py-3 bg-white rounded-xl shadow-sm cursor-pointer hover:bg-slate-50 transition-colors text-[10px] font-black uppercase tracking-widest">
+      <label className="flex flex-1 min-w-[140px] items-center justify-center gap-2 rounded-xl bg-white py-3 text-[10px] font-black uppercase tracking-widest shadow-sm cursor-pointer hover:bg-slate-50 transition-colors">
         <ImageIcon className="h-4 w-4 text-purple-600" /> Afbeelding
         <input type="file" accept="image/*" className="hidden" onChange={(e) => handleFileUpload(e, "img")} />
       </label>
+      {showPdf && (
+        <label className="flex flex-1 min-w-[140px] items-center justify-center gap-2 rounded-xl bg-white py-3 text-[10px] font-black uppercase tracking-widest shadow-sm cursor-pointer hover:bg-slate-50 transition-colors">
+          <FileText className="h-4 w-4 text-slate-600" /> PDF
+          <input type="file" accept="application/pdf" className="hidden" onChange={(e) => handleFileUpload(e, "pdf")} />
+        </label>
+      )}
     </div>
   );
 
-  // ─── Render ────────────────────────────────────────────────────────────────
+  const MarkdownSplitPane = ({
+    value,
+    onChange,
+    textareaRef,
+    placeholder,
+  }: {
+    value: string;
+    onChange: (value: string) => void;
+    textareaRef: React.RefObject<HTMLTextAreaElement>;
+    placeholder: string;
+  }) => (
+    <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+      <div className="space-y-2">
+        <label className="ml-1 text-[10px] font-black uppercase text-slate-400">Markdown (ruw)</label>
+        <textarea
+          ref={textareaRef}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder}
+          spellCheck={false}
+          className="h-[420px] w-full resize-y rounded-2xl border border-slate-200 bg-white p-4 font-mono text-sm leading-relaxed text-slate-900 focus:outline-none focus:ring-2 focus:ring-teal-500"
+        />
+      </div>
+      <div className="space-y-2">
+        <label className="ml-1 text-[10px] font-black uppercase text-slate-400">Live preview</label>
+        <div className="h-[420px] overflow-y-auto rounded-2xl border border-slate-200 bg-white p-4">
+          <MarkdownRenderer content={value} />
+        </div>
+      </div>
+    </div>
+  );
+
   return (
     <div className="min-h-screen bg-slate-50 pb-20 text-slate-900">
-      {/* Sticky header */}
-      <div className="bg-white border-b p-4 sticky top-0 z-50 flex items-center justify-between">
+      <div className="sticky top-0 z-50 flex items-center justify-between border-b bg-white p-4">
         <Button variant="ghost" size="sm" onClick={() => window.history.back()} className="rounded-xl">
-          <ArrowLeft className="h-4 w-4 mr-2" /> Terug
+          <ArrowLeft className="mr-2 h-4 w-4" /> Terug
         </Button>
         <h1 className="font-black uppercase tracking-tighter">Content Editor</h1>
-        <Button
-          onClick={handleSave}
-          disabled={loading}
-          className="bg-teal-600 hover:bg-teal-700 rounded-xl px-6 font-bold text-white"
-        >
-          {loading ? <Loader2 className="animate-spin h-4 w-4" /> : <Save className="h-4 w-4 mr-2" />}
+        <Button onClick={handleSave} disabled={loading} className="rounded-xl bg-teal-600 px-6 font-bold text-white hover:bg-teal-700">
+          {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="mr-2 h-4 w-4" />}
           OPSLAAN
         </Button>
       </div>
 
-      <div className="max-w-5xl mx-auto p-6 grid grid-cols-1 lg:grid-cols-3 gap-8">
-        <div className="lg:col-span-2 space-y-6">
-          <Card className="rounded-[2rem] border-slate-200 overflow-hidden shadow-sm">
-            <CardContent className="p-8 space-y-6">
-
-              {/* Module selector */}
+      <div className="mx-auto grid max-w-5xl grid-cols-1 gap-8 p-6 lg:grid-cols-3">
+        <div className="space-y-6 lg:col-span-2">
+          <Card className="overflow-hidden rounded-[2rem] border-slate-200 shadow-sm">
+            <CardContent className="space-y-6 p-8">
               <div className="space-y-2">
-                <label className="text-[10px] font-black uppercase text-slate-400 ml-1">Module</label>
+                <label className="ml-1 text-[10px] font-black uppercase text-slate-400">Module</label>
                 <Select value={type} onValueChange={(v: any) => { setType(v); setActiveTab("tab1"); }}>
-                  <SelectTrigger className="rounded-2xl border-slate-200 h-12 text-slate-900">
+                  <SelectTrigger className="h-12 rounded-2xl border-slate-200 text-slate-900">
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
@@ -400,46 +452,44 @@ export default function AdminEditor() {
                 </Select>
               </div>
 
-              {/* ── JOURNAL CLUB ────────────────────────────────────────────── */}
               {type === "journal_club" && (
                 <>
-                  {/* Discipline */}
                   <div className="space-y-2">
-                    <label className="text-[10px] font-black uppercase text-slate-400 ml-1">Discipline</label>
+                    <label className="ml-1 text-[10px] font-black uppercase text-slate-400">Discipline</label>
                     <Select value={discipline} onValueChange={setDiscipline}>
-                      <SelectTrigger className="rounded-2xl border-slate-200 h-12 text-slate-900">
+                      <SelectTrigger className="h-12 rounded-2xl border-slate-200 text-slate-900">
                         <SelectValue placeholder="Kies discipline…" />
                       </SelectTrigger>
                       <SelectContent>
                         {JOURNAL_DISCIPLINES.map((d) => (
-                          <SelectItem key={d} value={d}>{d}</SelectItem>
+                          <SelectItem key={d} value={d}>
+                            {d}
+                          </SelectItem>
                         ))}
                       </SelectContent>
                     </Select>
                   </div>
 
-                  {/* Titel */}
                   <div className="space-y-2">
-                    <label className="text-[10px] font-black uppercase text-slate-400 ml-1">Titel *</label>
+                    <label className="ml-1 text-[10px] font-black uppercase text-slate-400">Titel *</label>
                     <Input
                       value={title}
                       onChange={(e) => setTitle(e.target.value)}
                       placeholder="Verplicht"
-                      className="rounded-2xl border-slate-200 h-12 font-bold text-slate-900"
+                      className="h-12 rounded-2xl border-slate-200 font-bold text-slate-900"
                     />
                   </div>
 
-                  {/* PubMed ID */}
                   <div className="space-y-2">
-                    <label className="text-[10px] font-black uppercase text-slate-400 ml-1">
-                      PubMed ID <span className="font-normal normal-case">(optioneel — enkel het getal)</span>
+                    <label className="ml-1 text-[10px] font-black uppercase text-slate-400">
+                      PubMed ID <span className="normal-case font-normal">(optioneel — enkel het getal)</span>
                     </label>
                     <div className="relative">
                       <Input
                         value={pubmedId}
                         onChange={(e) => setPubmedId(e.target.value.replace(/\D/g, ""))}
                         placeholder="bv. 39512345"
-                        className="rounded-2xl border-slate-200 h-12 font-bold text-slate-900 pr-12"
+                        className="h-12 rounded-2xl border-slate-200 pr-12 font-bold text-slate-900"
                       />
                       {pubmedId && (
                         <a
@@ -455,48 +505,38 @@ export default function AdminEditor() {
                     </div>
                   </div>
 
-                  <UploadBar />
+                  <UploadBar showPdf />
 
-                  {/* Quill editor */}
-                  <div className="min-h-[400px]">
-                    <QuillEditor
-                      ref={genericContentRef}
-                      value={content}
-                      onChange={(val: string) => setContent(stripBase64Images(val))}
-                      className="h-[350px]"
-                      theme="snow"
-                      modules={QUILL_MODULES}
-                    />
-                  </div>
+                  <MarkdownSplitPane
+                    value={content}
+                    onChange={setContent}
+                    textareaRef={singleTextareaRef}
+                    placeholder={"# Journal club samenvatting\n\nSchrijf hier in pure Markdown..."}
+                  />
                 </>
               )}
 
-              {/* ── PROTOCOLS ───────────────────────────────────────────────── */}
               {type === "protocols" && (
                 <>
                   {migrateSlug && (
-                    <div className="rounded-2xl border border-amber-200 bg-amber-50 p-4 space-y-3">
-                      <div className="text-[10px] font-black uppercase tracking-widest text-amber-700">
-                        Lokale migratie
-                      </div>
+                    <div className="space-y-3 rounded-2xl border border-amber-200 bg-amber-50 p-4">
+                      <div className="text-[10px] font-black uppercase tracking-widest text-amber-700">Lokale migratie</div>
                       {protocolDraftToMigrate ? (
                         <>
                           <p className="text-xs text-amber-900">
-                            Bestand <span className="font-bold">{protocolDraftToMigrate.slug}.md</span> is geladen via
-                            {" "}
-                            <code>import.meta.glob</code>. Klik hieronder om frontmatter + markdown body direct naar
-                            Supabase te inserten.
+                            Bestand <span className="font-bold">{protocolDraftToMigrate.slug}.md</span> is geladen via{" "}
+                            <code>import.meta.glob</code>. Klik hieronder om frontmatter + markdown body direct naar Supabase te inserten.
                           </p>
                           <Button
                             type="button"
                             onClick={handleMigrateProtocolFile}
                             disabled={isMigratingProtocol}
-                            className="bg-amber-600 hover:bg-amber-700 text-white rounded-xl font-bold"
+                            className="rounded-xl bg-amber-600 font-bold text-white hover:bg-amber-700"
                           >
                             {isMigratingProtocol ? (
-                              <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                             ) : (
-                              <CloudDownload className="h-4 w-4 mr-2" />
+                              <CloudDownload className="mr-2 h-4 w-4" />
                             )}
                             MIGREER LOKAAL BESTAND
                           </Button>
@@ -510,78 +550,115 @@ export default function AdminEditor() {
                   )}
 
                   <div className="space-y-2">
-                    <label className="text-[10px] font-black uppercase text-slate-400 ml-1">Discipline</label>
+                    <label className="ml-1 text-[10px] font-black uppercase text-slate-400">Discipline</label>
                     <Select value={discipline} onValueChange={setDiscipline}>
-                      <SelectTrigger className="rounded-2xl border-slate-200 h-12 text-slate-900">
+                      <SelectTrigger className="h-12 rounded-2xl border-slate-200 text-slate-900">
                         <SelectValue placeholder="Kies discipline…" />
                       </SelectTrigger>
                       <SelectContent>
                         {PROTOCOL_DISCIPLINES.map((d) => (
-                          <SelectItem key={d} value={d}>{d}</SelectItem>
+                          <SelectItem key={d} value={d}>
+                            {d}
+                          </SelectItem>
                         ))}
                       </SelectContent>
                     </Select>
                   </div>
 
                   <div className="space-y-2">
-                    <label className="text-[10px] font-black uppercase text-slate-400 ml-1">Titel *</label>
+                    <label className="ml-1 text-[10px] font-black uppercase text-slate-400">Titel *</label>
                     <Input
                       value={title}
                       onChange={(e) => setTitle(e.target.value)}
                       placeholder="Verplicht"
-                      className="rounded-2xl border-slate-200 h-12 font-bold text-slate-900"
+                      className="h-12 rounded-2xl border-slate-200 font-bold text-slate-900"
                     />
                   </div>
 
-                  <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-                    <div className="space-y-2">
-                      <label className="text-[10px] font-black uppercase text-slate-400 ml-1">
-                        Markdown (ruw)
-                      </label>
-                      <textarea
-                        value={content}
-                        onChange={(e) => setContent(e.target.value)}
-                        placeholder={"# Titel\n\nSchrijf hier je protocol in pure Markdown..."}
-                        spellCheck={false}
-                        className="h-[420px] w-full resize-y rounded-2xl border border-slate-200 bg-white p-4 font-mono text-sm leading-relaxed text-slate-900 focus:outline-none focus:ring-2 focus:ring-teal-500"
-                      />
-                    </div>
+                  <UploadBar />
 
-                    <div className="space-y-2">
-                      <label className="text-[10px] font-black uppercase text-slate-400 ml-1">
-                        Live preview
-                      </label>
-                      <div className="h-[420px] overflow-y-auto rounded-2xl border border-slate-200 bg-white p-4">
-                        <MarkdownRenderer content={content} />
-                      </div>
-                    </div>
-                  </div>
+                  <MarkdownSplitPane
+                    value={content}
+                    onChange={setContent}
+                    textareaRef={singleTextareaRef}
+                    placeholder={"# Titel\n\nSchrijf hier je protocol in pure Markdown..."}
+                  />
                 </>
               )}
 
-              {/* ── POCUS + BLOCKS (multi-tab) ───────────────────────────────── */}
-              {isMultiTab(type) && (
+              {type === "blocks" && (
                 <>
                   <div className="space-y-2">
-                    <label className="text-[10px] font-black uppercase text-slate-400 ml-1">Titel *</label>
+                    <label className="ml-1 text-[10px] font-black uppercase text-slate-400">Titel *</label>
                     <Input
                       value={title}
                       onChange={(e) => setTitle(e.target.value)}
                       placeholder="Verplicht"
-                      className="rounded-2xl border-slate-200 h-12 font-bold text-slate-900"
+                      className="h-12 rounded-2xl border-slate-200 font-bold text-slate-900"
+                    />
+                  </div>
+
+                  <UploadBar />
+
+                  <Tabs value={activeTab} onValueChange={(v: string) => setActiveTab(v as "tab1" | "tab2" | "tab3")} className="w-full">
+                    <TabsList className="mb-4 grid h-12 w-full grid-cols-3 rounded-2xl bg-slate-100 p-1.5">
+                      {TAB_CONFIG.blocks.map((cfg, i) => (
+                        <TabsTrigger
+                          key={cfg.field}
+                          value={`tab${i + 1}` as "tab1" | "tab2" | "tab3"}
+                          className="rounded-xl text-[10px] font-black uppercase"
+                        >
+                          {cfg.label}
+                        </TabsTrigger>
+                      ))}
+                    </TabsList>
+
+                    <TabsContent value="tab1" className="outline-none">
+                      <MarkdownSplitPane
+                        value={tab1}
+                        onChange={setTab1}
+                        textareaRef={blockTextareaRef1}
+                        placeholder={"# Samenvatting\n\nAlgemene uitleg..."}
+                      />
+                    </TabsContent>
+                    <TabsContent value="tab2" className="outline-none">
+                      <MarkdownSplitPane
+                        value={tab2}
+                        onChange={setTab2}
+                        textareaRef={blockTextareaRef2}
+                        placeholder={"# Anatomie\n\nDiagrammen en afbeeldingen..."}
+                      />
+                    </TabsContent>
+                    <TabsContent value="tab3" className="outline-none">
+                      <MarkdownSplitPane
+                        value={tab3}
+                        onChange={setTab3}
+                        textareaRef={blockTextareaRef3}
+                        placeholder={"# Techniek\n\nPraktische tips en video's..."}
+                      />
+                    </TabsContent>
+                  </Tabs>
+                </>
+              )}
+
+              {type === "pocus" && (
+                <>
+                  <div className="space-y-2">
+                    <label className="ml-1 text-[10px] font-black uppercase text-slate-400">Titel *</label>
+                    <Input
+                      value={title}
+                      onChange={(e) => setTitle(e.target.value)}
+                      placeholder="Verplicht"
+                      className="h-12 rounded-2xl border-slate-200 font-bold text-slate-900"
                     />
                   </div>
 
                   <UploadBar />
 
                   <div className="min-h-[440px]">
-                    <Tabs
-                      value={activeTab}
-                      onValueChange={(v: string) => setActiveTab(v as "tab1" | "tab2" | "tab3")}
-                      className="w-full"
-                    >
-                      <TabsList className="grid w-full grid-cols-3 bg-slate-100 p-1.5 rounded-2xl h-12 mb-4">
-                        {TAB_CONFIG[type].map((cfg, i) => (
+                    <Tabs value={activeTab} onValueChange={(v: string) => setActiveTab(v as "tab1" | "tab2" | "tab3")} className="w-full">
+                      <TabsList className="mb-4 grid h-12 w-full grid-cols-3 rounded-2xl bg-slate-100 p-1.5">
+                        {TAB_CONFIG.pocus.map((cfg, i) => (
                           <TabsTrigger
                             key={cfg.field}
                             value={`tab${i + 1}` as "tab1" | "tab2" | "tab3"}
@@ -594,7 +671,7 @@ export default function AdminEditor() {
 
                       <TabsContent value="tab1" className="outline-none">
                         <QuillEditor
-                          ref={tabRef1}
+                          ref={pocusRef1}
                           value={tab1}
                           onChange={(val: string) => setTab1(stripBase64Images(val))}
                           className="h-[350px]"
@@ -604,7 +681,7 @@ export default function AdminEditor() {
                       </TabsContent>
                       <TabsContent value="tab2" className="outline-none">
                         <QuillEditor
-                          ref={tabRef2}
+                          ref={pocusRef2}
                           value={tab2}
                           onChange={(val: string) => setTab2(stripBase64Images(val))}
                           className="h-[350px]"
@@ -614,7 +691,7 @@ export default function AdminEditor() {
                       </TabsContent>
                       <TabsContent value="tab3" className="outline-none">
                         <QuillEditor
-                          ref={tabRef3}
+                          ref={pocusRef3}
                           value={tab3}
                           onChange={(val: string) => setTab3(stripBase64Images(val))}
                           className="h-[350px]"
@@ -626,35 +703,33 @@ export default function AdminEditor() {
                   </div>
                 </>
               )}
-
             </CardContent>
           </Card>
         </div>
 
-        {/* Design Gids */}
         <div className="space-y-4">
-          <div className="bg-white p-6 rounded-[2rem] border border-slate-200 shadow-sm space-y-6">
-            <div className="flex items-center gap-2 text-slate-900 border-b pb-4">
+          <div className="space-y-6 rounded-[2rem] border border-slate-200 bg-white p-6 shadow-sm">
+            <div className="flex items-center gap-2 border-b pb-4 text-slate-900">
               <HelpCircle className="h-5 w-5 text-teal-600" />
-              <h3 className="font-black uppercase tracking-tight text-sm">Design Gids</h3>
+              <h3 className="text-sm font-black uppercase tracking-tight">Design Gids</h3>
             </div>
             <div className="space-y-4 text-[11px] font-medium leading-relaxed text-slate-600">
-              <section className="p-4 bg-slate-50 rounded-2xl border border-slate-100 text-slate-900">
-                <p className="font-black uppercase mb-1 underline">Blauwe Lijn (H2)</p>
-                <p>Selecteer tekst → <b>Koptekst 2</b>.</p>
+              <section className="rounded-2xl border border-slate-100 bg-slate-50 p-4 text-slate-900">
+                <p className="mb-1 font-black uppercase underline">Markdown editor</p>
+                <p>Schrijf direct in Markdown. Rechts zie je onmiddellijk de live preview.</p>
               </section>
-              <section className="p-4 bg-emerald-50 rounded-2xl border border-emerald-100 text-emerald-900">
-                <p className="font-black uppercase mb-1 underline">Groen Kader</p>
-                <p className="italic">Druk op Quote (") en typ je tekst.</p>
+              <section className="rounded-2xl border border-emerald-100 bg-emerald-50 p-4 text-emerald-900">
+                <p className="mb-1 font-black uppercase underline">Callouts</p>
+                <p>Gebruik <code>&gt; [!INFO]</code>, <code>&gt; [!TIP]</code> en <code>&gt; [!WARNING]</code>.</p>
               </section>
-              <section className="p-4 bg-amber-50 rounded-2xl border border-amber-100 text-amber-900">
-                <p className="font-black uppercase mb-1 underline">Video invoegen</p>
-                <p>Klik <b>eerst</b> op de gewenste positie in de tekst, dan op de Video-knop.</p>
+              <section className="rounded-2xl border border-amber-100 bg-amber-50 p-4 text-amber-900">
+                <p className="mb-1 font-black uppercase underline">Media invoegen</p>
+                <p>Klik eerst op je cursorpositie en gebruik dan de Video/Afbeelding/PDF knop.</p>
               </section>
               {type === "journal_club" && (
-                <section className="p-4 bg-blue-50 rounded-2xl border border-blue-100 text-blue-900">
-                  <p className="font-black uppercase mb-1 underline">PubMed</p>
-                  <p>Vul enkel het getal in (bv. <b>39512345</b>). De link wordt automatisch aangemaakt.</p>
+                <section className="rounded-2xl border border-blue-100 bg-blue-50 p-4 text-blue-900">
+                  <p className="mb-1 font-black uppercase underline">PubMed</p>
+                  <p>Vul enkel het nummer in (bv. <b>39512345</b>). De link wordt automatisch gemaakt.</p>
                 </section>
               )}
             </div>

--- a/client/src/pages/admin-editor.tsx
+++ b/client/src/pages/admin-editor.tsx
@@ -51,6 +51,11 @@ const PROTOCOL_DISCIPLINES = [
 ];
 
 const JOURNAL_DISCIPLINES = ["Anesthesie", "Intensieve", "Urgentie", "Pijn"];
+const PROTOCOL_DISCIPLINE_ALIASES: Record<string, string> = {
+  obstetrie: "Obstetrie-epidurale",
+  "obstetrie epidurale": "Obstetrie-epidurale",
+  obstetrie_epidurale: "Obstetrie-epidurale",
+};
 
 const QUILL_MODULES = {
   toolbar: [
@@ -100,6 +105,23 @@ const inferDisciplineFromProtocolPath = (path: string): string => {
     .split("-")
     .map((part) => (part ? `${part.charAt(0).toUpperCase()}${part.slice(1)}` : part))
     .join("-");
+};
+
+const normalizeProtocolDiscipline = (discipline?: string): string => {
+  const raw = (discipline || "").trim();
+  if (!raw) return "Algemeen";
+
+  const lowered = raw.replace(/_/g, " ").trim().toLowerCase();
+  if (PROTOCOL_DISCIPLINE_ALIASES[lowered]) {
+    return PROTOCOL_DISCIPLINE_ALIASES[lowered];
+  }
+
+  const known = PROTOCOL_DISCIPLINES.find((candidate) => candidate.toLowerCase() === lowered.replace(/\s+/g, "-"));
+  if (known) return known;
+
+  if (lowered.startsWith("obstetrie")) return "Obstetrie-epidurale";
+
+  return raw;
 };
 
 type TextSetter = React.Dispatch<React.SetStateAction<string>>;
@@ -182,7 +204,7 @@ export default function AdminEditor() {
     return {
       slug: migrateSlug,
       title: frontmatter.title || migrateSlug.replace(/-/g, " "),
-      discipline: frontmatter.discipline || inferDisciplineFromProtocolPath(fileKey),
+      discipline: normalizeProtocolDiscipline(frontmatter.discipline || inferDisciplineFromProtocolPath(fileKey)),
       content: body,
     };
   }, [migrateSlug, type]);
@@ -213,7 +235,7 @@ export default function AdminEditor() {
       }
 
       setContent(data.content || "");
-      setDiscipline(data.discipline || "");
+      setDiscipline(normalizeProtocolDiscipline(data.discipline || ""));
     };
 
     fetchData();
@@ -335,7 +357,7 @@ export default function AdminEditor() {
       if (type === "protocols") {
         const payload = {
           title: title.trim(),
-          discipline: discipline || "Algemeen",
+          discipline: normalizeProtocolDiscipline(discipline || "Algemeen"),
           content,
         };
         const result = editId
@@ -387,7 +409,7 @@ export default function AdminEditor() {
     try {
       const payload = {
         title: protocolDraftToMigrate.title,
-        discipline: protocolDraftToMigrate.discipline,
+        discipline: normalizeProtocolDiscipline(protocolDraftToMigrate.discipline),
         content: protocolDraftToMigrate.content,
       };
 
@@ -717,8 +739,13 @@ export default function AdminEditor() {
             </div>
             <div className="space-y-4 text-[11px] font-medium leading-relaxed text-slate-600">
               <section className="rounded-2xl border border-slate-100 bg-slate-50 p-4 text-slate-900">
-                <p className="mb-1 font-black uppercase underline">Markdown editor</p>
-                <p>Schrijf direct in Markdown. Rechts zie je onmiddellijk de live preview.</p>
+                <p className="mb-2 font-black uppercase underline">Markdown basics</p>
+                <ul className="space-y-1 text-[11px]">
+                  <li><code>**vet**</code> = <b>vet</b></li>
+                  <li><code>*cursief*</code> = <i>cursief</i></li>
+                  <li><code>onderlijnd</code> = niet standaard in pure Markdown</li>
+                  <li><code>## Kop 2</code> / <code>### Kop 3</code></li>
+                </ul>
               </section>
               <section className="rounded-2xl border border-emerald-100 bg-emerald-50 p-4 text-emerald-900">
                 <p className="mb-1 font-black uppercase underline">Callouts</p>

--- a/client/src/pages/protocol-detail.tsx
+++ b/client/src/pages/protocol-detail.tsx
@@ -71,7 +71,9 @@ export default function ProtocolDetail() {
         </h1>
         <div className="flex items-center text-[10px] font-black uppercase tracking-widest text-slate-400 mb-8">
           <Clock className="h-3 w-3 mr-1" /> 
-          {dbProtocol ? `Laatste update: ${new Date(dbProtocol.created_at).toLocaleDateString('nl-BE')}` : "Lokaal bestand"}
+          {dbProtocol
+            ? `Laatste update: ${new Date(dbProtocol.updated_at || dbProtocol.created_at).toLocaleDateString('nl-BE')}`
+            : "Lokaal bestand"}
         </div>
 
         <div className="prose prose-slate max-w-none">

--- a/client/src/pages/protocol-list.tsx
+++ b/client/src/pages/protocol-list.tsx
@@ -47,15 +47,25 @@ const KNOWN_DISCIPLINES = [
   "Pediatrie",
   "Algemeen",
 ];
+const DISCIPLINE_ALIASES: Record<string, string> = {
+  obstetrie: "Obstetrie-epidurale",
+  "obstetrie epidurale": "Obstetrie-epidurale",
+  obstetrie_epidurale: "Obstetrie-epidurale",
+};
 
 const normalizeDiscipline = (discipline?: string) => {
   if (!discipline) return "Algemeen";
-  const cleaned = discipline.trim().replace(/_/g, "-");
+  const cleaned = discipline.trim().replace(/_/g, " ");
   const lower = cleaned.toLowerCase();
-  const known = KNOWN_DISCIPLINES.find((candidate) => candidate.toLowerCase() === lower);
+  if (DISCIPLINE_ALIASES[lower]) return DISCIPLINE_ALIASES[lower];
+  if (lower.startsWith("obstetrie")) return "Obstetrie-epidurale";
+
+  const known = KNOWN_DISCIPLINES.find(
+    (candidate) => candidate.toLowerCase() === lower || candidate.toLowerCase() === lower.replace(/\s+/g, "-")
+  );
   if (known) return known;
   return cleaned
-    .split("-")
+    .split(/[-\s]+/)
     .map((part) => (part ? `${part.charAt(0).toUpperCase()}${part.slice(1)}` : part))
     .join("-");
 };

--- a/client/src/pages/protocol-list.tsx
+++ b/client/src/pages/protocol-list.tsx
@@ -29,7 +29,8 @@ interface DbProtocol {
   title: string;
   discipline: string;
   content: string;
-  created_at: string;
+  updated_at?: string;
+  created_at?: string;
 }
 
 const allProtocols = import.meta.glob('../content/protocols/**/*.md', { query: 'raw', eager: true });

--- a/client/src/pages/protocol-list.tsx
+++ b/client/src/pages/protocol-list.tsx
@@ -1,5 +1,5 @@
-import { useState, useMemo } from "react";
-import { Link } from "wouter";
+import { useState, useMemo, useEffect } from "react";
+import { Link, useSearch } from "wouter";
 import { Card, CardContent } from "@/components/ui/card";
 import { useQuery } from "@tanstack/react-query";
 import { supabase } from "@/lib/supabase";
@@ -11,7 +11,6 @@ import {
   Activity, 
   Bone, 
   Baby, 
-  HeartPulse, 
   GlassWater,
   Hamburger,
   Brain,
@@ -34,8 +33,36 @@ interface DbProtocol {
 }
 
 const allProtocols = import.meta.glob('../content/protocols/**/*.md', { query: 'raw', eager: true });
+const KNOWN_DISCIPLINES = [
+  "Abdominale",
+  "Buitendiensten",
+  "Neurochirurgie",
+  "NKO",
+  "Obstetrie-epidurale",
+  "Orthopedie",
+  "Pijnkliniek",
+  "Reanimatie",
+  "Thorax-vaat",
+  "Urologie",
+  "Pediatrie",
+  "Algemeen",
+];
+
+const normalizeDiscipline = (discipline?: string) => {
+  if (!discipline) return "Algemeen";
+  const cleaned = discipline.trim().replace(/_/g, "-");
+  const lower = cleaned.toLowerCase();
+  const known = KNOWN_DISCIPLINES.find((candidate) => candidate.toLowerCase() === lower);
+  if (known) return known;
+  return cleaned
+    .split("-")
+    .map((part) => (part ? `${part.charAt(0).toUpperCase()}${part.slice(1)}` : part))
+    .join("-");
+};
 
 export default function ProtocolList() {
+  const search = useSearch();
+  const queryDiscipline = new URLSearchParams(search).get("discipline");
   const [activeDiscipline, setActiveDiscipline] = useState<string | null>(null);
 
   // 1. Haal Cloud data op
@@ -80,7 +107,7 @@ export default function ProtocolList() {
       return {
         id: fileName,
         title: titleMatch ? titleMatch[1] : fileName.replace(/-/g, ' '),
-        discipline,
+        discipline: normalizeDiscipline(discipline),
         isCloud: false
       };
     });
@@ -88,12 +115,26 @@ export default function ProtocolList() {
     const cloud = (dbProtocols || []).map((p: DbProtocol) => ({
       id: p.id,
       title: p.title,
-      discipline: p.discipline || 'Algemeen',
+      discipline: normalizeDiscipline(p.discipline || 'Algemeen'),
       isCloud: true
     }));
 
-    return [...local, ...cloud].sort((a, b) => a.title.localeCompare(b.title));
+    const merged = [...local, ...cloud];
+    const byTitleAndDiscipline = new Map<string, typeof merged[number]>();
+
+    for (const item of merged) {
+      const key = `${item.discipline.toLowerCase()}::${item.title.trim().toLowerCase()}`;
+      const existing = byTitleAndDiscipline.get(key);
+      if (!existing || item.isCloud) byTitleAndDiscipline.set(key, item);
+    }
+
+    return Array.from(byTitleAndDiscipline.values()).sort((a, b) => a.title.localeCompare(b.title));
   }, [dbProtocols]);
+
+  useEffect(() => {
+    if (!queryDiscipline) return;
+    setActiveDiscipline(normalizeDiscipline(queryDiscipline));
+  }, [queryDiscipline]);
 
   const disciplines = useMemo(() => {
     const set = new Set(protocols.map(p => p.discipline));
@@ -104,6 +145,13 @@ export default function ProtocolList() {
 
   return (
     <div className="min-h-screen bg-slate-50 pb-24 px-4 pt-8">
+      {!activeDiscipline && (
+        <Link href="/">
+          <div className="flex items-center text-slate-400 font-black uppercase text-[10px] tracking-widest cursor-pointer py-2 mb-4 hover:text-teal-600 transition-colors">
+            <ChevronLeft className="h-4 w-4 mr-1" /> Home
+          </div>
+        </Link>
+      )}
       
       <div className="mb-8">
         <h1 className="text-4xl font-black tracking-tightest uppercase text-slate-900 leading-none mb-2">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- refactor `client/src/components/MarkdownRenderer.tsx` into a pure Markdown-first renderer based on `react-markdown`
- add `remark-breaks` so authored Markdown line breaks are rendered as expected
- centralize custom rendering for `[!INFO]`, `[!TIP]`, `[!WARNING]/[!CAUTION]` callouts and `video:`/`video://`/`[VIDEO:...]` tags
- update the protocols admin flow in `client/src/pages/admin-editor.tsx` to a split-pane Markdown CMS
- make protocol saving explicit via `supabase.from('protocols')` with payload `{ title, discipline, content }`
- add `PROTOCOLS_SCHEMA_RESET.sql` for Supabase schema normalization + cleanup
- add one-click local protocol migration in admin via `?type=protocols&migrate=<slug>`

## Additional polish requested after testing
- fix duplicate discipline cards on `/protocols` by normalizing discipline names and deduplicating merged local/cloud protocol entries (cloud wins on duplicate title+discipline)
- reintroduce a top-level `Home` back button on the protocols main page
- make media upload buttons available on every admin edit flow (including PDF for journal club)
- upgrade Blocks editor to markdown split-pane with Samenvatting/Anatomie/Techniek tabs
- upgrade Journal Club editor to markdown split-pane while preserving discipline/title/pubmed/pdf workflow

## Follow-up bugfixes
- fix markdown editor cursor/scroll jumping after each keystroke by moving split-pane component to module scope (no remount per keystroke)
- normalize `Obstetrie` discipline alias to `Obstetrie-epidurale` in both admin save/migration flow and protocol list rendering, preventing split folders after migration of legacy files
- add a concise Markdown basics cheat sheet in the right-side info panel of the editor
- add optional `Obstetrie` discipline SQL cleanup snippet into `PROTOCOLS_SCHEMA_RESET.sql`
- fix SQL migration robustness by backfilling existing NULL/empty `title/content/discipline/updated_at` values before applying NOT NULL constraints

## Validation
- `npx eslint client/src/pages/admin-editor.tsx --max-warnings=0`
- `npx eslint client/src/pages/admin-editor.tsx client/src/pages/protocol-list.tsx --max-warnings=0`
- project-wide lint still has unrelated pre-existing warnings in other files
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-413fbd75-2d83-4cae-a2c5-111222165a20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-413fbd75-2d83-4cae-a2c5-111222165a20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

