### PR TITLE
Fix strict TypeScript build errors in admin editor

### DIFF
--- a/client/src/components/MarkdownRenderer.tsx
+++ b/client/src/components/MarkdownRenderer.tsx
@@ -28,7 +28,6 @@ const cleanCalloutTokens = (node: any): any => {
 
   if (React.isValidElement(node)) {
     return React.cloneElement(node, {
-      ...node.props,
       children: cleanCalloutTokens((node.props as any).children),
     } as any);
   }

--- a/client/src/pages/admin-editor.tsx
+++ b/client/src/pages/admin-editor.tsx
@@ -134,7 +134,7 @@ function MarkdownSplitPane({
 }: {
   value: string;
   onChange: (value: string) => void;
-  textareaRef: React.RefObject<HTMLTextAreaElement>;
+  textareaRef: React.RefObject<HTMLTextAreaElement | null>;
   placeholder: string;
 }) {
   return (
@@ -255,7 +255,7 @@ export default function AdminEditor() {
     return setTab3;
   };
 
-  const getActiveTextareaRef = (): React.RefObject<HTMLTextAreaElement> | null => {
+  const getActiveTextareaRef = (): React.RefObject<HTMLTextAreaElement | null> | null => {
     if (type === "protocols" || type === "journal_club") return singleTextareaRef;
     if (type !== "blocks") return null;
     if (activeTab === "tab1") return blockTextareaRef1;
@@ -271,7 +271,7 @@ export default function AdminEditor() {
   };
 
   const insertTextAtCursorInTextarea = (
-    ref: React.RefObject<HTMLTextAreaElement>,
+    ref: React.RefObject<HTMLTextAreaElement | null>,
     valueToInsert: string,
     setter: TextSetter
   ): boolean => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- fix strict ref typing in `client/src/pages/admin-editor.tsx` by using nullable textarea ref types (`RefObject<HTMLTextAreaElement | null>`) compatible with TypeScript 5.6 strict checks
- fix `client/src/components/MarkdownRenderer.tsx` compile issue by removing spread on `node.props` inside `React.cloneElement`, which triggered `TS2698` under strict typing

## Why
Vercel build failed with TypeScript errors (`TS2322` for textarea refs and `TS2698` in markdown renderer), so this patch keeps the existing behavior while making the code compile cleanly on strict CI.

## Validation
- `npm run check`
- `npx eslint client/src/pages/admin-editor.tsx client/src/components/MarkdownRenderer.tsx --max-warnings=0`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-413fbd75-2d83-4cae-a2c5-111222165a20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-413fbd75-2d83-4cae-a2c5-111222165a20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

