### PR TITLE
Fix calculator page 404 after launch

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -156,10 +156,12 @@ function Router() {
           <Route path="/protocols/:id" component={ProtocolDetail} />
           <Route path="/blocks" component={Blocks} />
           <Route path="/blocks/:id" component={BlockDetail} />
+          <Route path="/calculator" component={CalculatorList} />
           <Route path="/calculators" component={CalculatorList} />
           <Route path="/calculator/last" component={CalculatorPage} />
           <Route path="/calculator/apfel" component={ApfelCalculator} />
           <Route path="/calculator/peds" component={PedsCalculator} />
+          <Route path="/calculator/peds-calculator" component={PedsCalculator} />
           <Route path="/calculator/dantroleen" component={DantroleenPage} />
           <Route path="/calculator/painpump" component={PainPumpPage} />
           <Route path="/contacts" component={ContactsPage} />

--- a/client/src/pages/calculator-list.tsx
+++ b/client/src/pages/calculator-list.tsx
@@ -54,7 +54,7 @@ const calculators = [
     id: "peds",
     title: "Pediatrische doses",
     description: "Tubes, noodmedicatie,...",
-    path: "/calculator/peds-calculator",
+    path: "/calculator/peds",
     icon: <Baby className="h-5 w-5 text-pink-600" />,
     color: "bg-pink-50/50",
     iconBg: "bg-pink-100"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Probleem
Na de launch gaf `/calculator` een 404. De homepagina en terug-links op individuele calculators verwezen naar `/calculator`, terwijl de router alleen `/calculators` (meervoud) kende.

## Oplossing
- Route `/calculator` toegevoegd → `CalculatorList` (primair pad)
- `/calculators` blijft werken als alias
- Pediatrische calculator-link gecorrigeerd: `/calculator/peds-calculator` → `/calculator/peds`
- `/calculator/peds-calculator` blijft als backwards-compatible alias

## Test
- `npm run build` slaagt
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-413fbd75-2d83-4cae-a2c5-111222165a20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-413fbd75-2d83-4cae-a2c5-111222165a20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

