### PR TITLE
Add [CAUDAL_CALC] shortcode for LRA block pages

### DIFF
--- a/client/src/pages/admin-editor.tsx
+++ b/client/src/pages/admin-editor.tsx
@@ -755,6 +755,15 @@ export default function AdminEditor() {
                 <p className="mb-1 font-black uppercase underline">Media invoegen</p>
                 <p>Klik eerst op je cursorpositie en gebruik dan de Video/Afbeelding/PDF knop.</p>
               </section>
+              {type === "blocks" && (
+                <section className="rounded-2xl border border-orange-100 bg-orange-50 p-4 text-orange-900">
+                  <p className="mb-1 font-black uppercase underline">Calculators</p>
+                  <p>
+                    Plaats <code>[CAUDAL_CALC]</code> op een nieuwe regel in Algemeen, Anatomie of Techniek om de
+                    Caudaal Volume Calculator te tonen.
+                  </p>
+                </section>
+              )}
               {type === "journal_club" && (
                 <section className="rounded-2xl border border-blue-100 bg-blue-50 p-4 text-blue-900">
                   <p className="mb-1 font-black uppercase underline">PubMed</p>

--- a/client/src/pages/block-detail.tsx
+++ b/client/src/pages/block-detail.tsx
@@ -9,6 +9,20 @@ import CaudalCalculator from "@/components/CaudalCalculator";
 
 const allBlocks = import.meta.glob('../content/blocks/*.md', { query: 'raw', eager: true });
 
+const CAUDAL_CALC_SHORTCODE = "[CAUDAL_CALC]";
+
+function BlockTabContent({ content }: { content: string }) {
+  const showCaudalCalc = content.includes(CAUDAL_CALC_SHORTCODE);
+  const markdown = content.replaceAll(CAUDAL_CALC_SHORTCODE, "").trim();
+
+  return (
+    <>
+      <MarkdownRenderer content={markdown} />
+      {showCaudalCalc && <CaudalCalculator />}
+    </>
+  );
+}
+
 export default function BlockDetail() {
   const [, params] = useRoute("/blocks/:id");
   const id = params?.id;
@@ -82,14 +96,13 @@ export default function BlockDetail() {
           </TabsList>
           
           <TabsContent value="algemeen" className="mt-6 prose prose-slate max-w-none">
-            <MarkdownRenderer content={dbBlock?.content_general || local.general} />
-            {id === "caudaal-blok" && <CaudalCalculator />}
+            <BlockTabContent content={dbBlock?.content_general || local.general} />
           </TabsContent>
           <TabsContent value="anatomie" className="mt-6 prose prose-slate max-w-none">
-            <MarkdownRenderer content={dbBlock?.content_anatomy || local.anatomy} />
+            <BlockTabContent content={dbBlock?.content_anatomy || local.anatomy} />
           </TabsContent>
           <TabsContent value="techniek" className="mt-6 prose prose-slate max-w-none">
-            <MarkdownRenderer content={dbBlock?.content_technique || local.technique} />
+            <BlockTabContent content={dbBlock?.content_technique || local.technique} />
           </TabsContent>
         </Tabs>
       </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Doel
De Caudaal Volume Calculator weer beschikbaar maken via het CMS, ook na Supabase-migratie (UUID-routes).

## Wijziging
- Vervangt hardcoded `id === "caudaal-blok"` check door shortcode `[CAUDAL_CALC]`
- Werkt op alle drie tabs: Algemeen, Anatomie, Techniek
- Shortcode wordt uit de gerenderde markdown gefilterd
- Designgids in blocks-editor documenteert het gebruik

## Gebruik in CMS
Plaats op een nieuwe regel in de gewenste tab:

```
[CAUDAL_CALC]
```

## Test
- `npm run check` slaagt
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-413fbd75-2d83-4cae-a2c5-111222165a20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-413fbd75-2d83-4cae-a2c5-111222165a20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

