### PR TITLE
POCUS CMS: markdown editor with 3 tabs and media uploads

### DIFF
--- a/POCUS_SCHEMA.sql
+++ b/POCUS_SCHEMA.sql
@@ -1,0 +1,37 @@
+-- POCUS table for Supabase CMS (3 markdown tabs).
+-- Run in Supabase SQL Editor if needed.
+
+create extension if not exists pgcrypto;
+
+create table if not exists public.pocus (
+  id uuid primary key default gen_random_uuid(),
+  title text not null,
+  content_indicaties text not null default '',
+  content_techniek text not null default '',
+  content_interpretatie text not null default '',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.pocus
+  add column if not exists title text,
+  add column if not exists content_indicaties text,
+  add column if not exists content_techniek text,
+  add column if not exists content_interpretatie text,
+  add column if not exists updated_at timestamptz;
+
+create or replace function public.set_pocus_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists pocus_updated_at on public.pocus;
+create trigger pocus_updated_at
+before update on public.pocus
+for each row
+execute function public.set_pocus_updated_at();

--- a/client/src/pages/admin-editor.tsx
+++ b/client/src/pages/admin-editor.tsx
@@ -20,10 +20,6 @@ import {
 } from "lucide-react";
 import { MarkdownRenderer } from "@/components/MarkdownRenderer";
 import { compressImageForUpload, formatCompressionSummary } from "@/lib/compress-image";
-import ReactQuill from "react-quill-new";
-import "react-quill-new/dist/quill.snow.css";
-
-const QuillEditor = ReactQuill as any;
 
 const TAB_CONFIG: Record<string, { label: string; field: string }[]> = {
   pocus: [
@@ -57,17 +53,6 @@ const PROTOCOL_DISCIPLINE_ALIASES: Record<string, string> = {
   "obstetrie epidurale": "Obstetrie-epidurale",
   obstetrie_epidurale: "Obstetrie-epidurale",
 };
-
-const QUILL_MODULES = {
-  toolbar: [
-    [{ header: [2, 3, false] }],
-    ["bold", "italic", "underline", "strike", "blockquote"],
-    [{ list: "ordered" }, { list: "bullet" }],
-    ["clean"],
-  ],
-};
-
-const stripBase64Images = (html: string): string => html.replace(/<img[^>]+src="data:[^">]+"[^>]*>/gi, "");
 
 const localProtocolFiles = import.meta.glob("../content/protocols/**/*.md", { query: "raw", eager: true });
 
@@ -184,13 +169,13 @@ export default function AdminEditor() {
   const [isMigratingProtocol, setIsMigratingProtocol] = useState(false);
   const [activeTab, setActiveTab] = useState<"tab1" | "tab2" | "tab3">("tab1");
 
-  const pocusRef1 = useRef<any>(null);
-  const pocusRef2 = useRef<any>(null);
-  const pocusRef3 = useRef<any>(null);
   const singleTextareaRef = useRef<HTMLTextAreaElement>(null);
   const blockTextareaRef1 = useRef<HTMLTextAreaElement>(null);
   const blockTextareaRef2 = useRef<HTMLTextAreaElement>(null);
   const blockTextareaRef3 = useRef<HTMLTextAreaElement>(null);
+  const pocusTextareaRef1 = useRef<HTMLTextAreaElement>(null);
+  const pocusTextareaRef2 = useRef<HTMLTextAreaElement>(null);
+  const pocusTextareaRef3 = useRef<HTMLTextAreaElement>(null);
 
   const protocolDraftToMigrate = useMemo(() => {
     if (type !== "protocols" || !migrateSlug) return null;
@@ -260,17 +245,16 @@ export default function AdminEditor() {
 
   const getActiveTextareaRef = (): React.RefObject<HTMLTextAreaElement | null> | null => {
     if (type === "protocols" || type === "journal_club") return singleTextareaRef;
-    if (type !== "blocks") return null;
-    if (activeTab === "tab1") return blockTextareaRef1;
-    if (activeTab === "tab2") return blockTextareaRef2;
-    return blockTextareaRef3;
-  };
-
-  const getActivePocusRef = (): React.RefObject<any> | null => {
-    if (type !== "pocus") return null;
-    if (activeTab === "tab1") return pocusRef1;
-    if (activeTab === "tab2") return pocusRef2;
-    return pocusRef3;
+    if (type === "blocks" || type === "pocus") {
+      const refs =
+        type === "blocks"
+          ? [blockTextareaRef1, blockTextareaRef2, blockTextareaRef3]
+          : [pocusTextareaRef1, pocusTextareaRef2, pocusTextareaRef3];
+      if (activeTab === "tab1") return refs[0];
+      if (activeTab === "tab2") return refs[1];
+      return refs[2];
+    }
+    return null;
   };
 
   const insertTextAtCursorInTextarea = (
@@ -291,20 +275,6 @@ export default function AdminEditor() {
       ref.current.focus();
       ref.current.setSelectionRange(cursor, cursor);
     });
-    return true;
-  };
-
-  const insertTextAtCursorInQuill = (ref: React.RefObject<any>, valueToInsert: string): boolean => {
-    const instance = ref.current;
-    if (!instance) return false;
-    const quill = instance.getEditor ? instance.getEditor() : instance;
-    if (!quill) return false;
-
-    quill.focus?.();
-    const range = quill.getSelection() || quill.getSelection(true) || null;
-    const index = range ? range.index : quill.getLength();
-    quill.insertText(index, valueToInsert, "user");
-    quill.setSelection(index + valueToInsert.length, 0, "user");
     return true;
   };
 
@@ -343,12 +313,10 @@ export default function AdminEditor() {
 
       const setter = getActiveSetter();
       const textareaRef = getActiveTextareaRef();
-      const quillRef = getActivePocusRef();
       const snippet = buildUploadSnippet(fileType, publicUrl, uploadFile.name);
 
       let inserted = false;
       if (textareaRef) inserted = insertTextAtCursorInTextarea(textareaRef, snippet, setter);
-      if (!inserted && quillRef) inserted = insertTextAtCursorInQuill(quillRef, snippet);
       if (!inserted) setter((prev) => `${prev}${snippet}`);
 
       if (fileType === "img" && imageCompressResult) {
@@ -721,54 +689,46 @@ export default function AdminEditor() {
                     />
                   </div>
 
-                  <UploadBar />
+                  <UploadBar showPdf />
 
-                  <div className="min-h-[440px]">
-                    <Tabs value={activeTab} onValueChange={(v: string) => setActiveTab(v as "tab1" | "tab2" | "tab3")} className="w-full">
-                      <TabsList className="mb-4 grid h-12 w-full grid-cols-3 rounded-2xl bg-slate-100 p-1.5">
-                        {TAB_CONFIG.pocus.map((cfg, i) => (
-                          <TabsTrigger
-                            key={cfg.field}
-                            value={`tab${i + 1}` as "tab1" | "tab2" | "tab3"}
-                            className="rounded-xl text-[10px] font-black uppercase"
-                          >
-                            {cfg.label}
-                          </TabsTrigger>
-                        ))}
-                      </TabsList>
+                  <Tabs value={activeTab} onValueChange={(v: string) => setActiveTab(v as "tab1" | "tab2" | "tab3")} className="w-full">
+                    <TabsList className="mb-4 grid h-12 w-full grid-cols-3 rounded-2xl bg-slate-100 p-1.5">
+                      {TAB_CONFIG.pocus.map((cfg, i) => (
+                        <TabsTrigger
+                          key={cfg.field}
+                          value={`tab${i + 1}` as "tab1" | "tab2" | "tab3"}
+                          className="rounded-xl text-[10px] font-black uppercase"
+                        >
+                          {cfg.label}
+                        </TabsTrigger>
+                      ))}
+                    </TabsList>
 
-                      <TabsContent value="tab1" className="outline-none">
-                        <QuillEditor
-                          ref={pocusRef1}
-                          value={tab1}
-                          onChange={(val: string) => setTab1(stripBase64Images(val))}
-                          className="h-[350px]"
-                          theme="snow"
-                          modules={QUILL_MODULES}
-                        />
-                      </TabsContent>
-                      <TabsContent value="tab2" className="outline-none">
-                        <QuillEditor
-                          ref={pocusRef2}
-                          value={tab2}
-                          onChange={(val: string) => setTab2(stripBase64Images(val))}
-                          className="h-[350px]"
-                          theme="snow"
-                          modules={QUILL_MODULES}
-                        />
-                      </TabsContent>
-                      <TabsContent value="tab3" className="outline-none">
-                        <QuillEditor
-                          ref={pocusRef3}
-                          value={tab3}
-                          onChange={(val: string) => setTab3(stripBase64Images(val))}
-                          className="h-[350px]"
-                          theme="snow"
-                          modules={QUILL_MODULES}
-                        />
-                      </TabsContent>
-                    </Tabs>
-                  </div>
+                    <TabsContent value="tab1" className="outline-none">
+                      <MarkdownSplitPane
+                        value={tab1}
+                        onChange={setTab1}
+                        textareaRef={pocusTextareaRef1}
+                        placeholder={"# Indicaties\n\nWanneer en waarom deze scan uitvoeren..."}
+                      />
+                    </TabsContent>
+                    <TabsContent value="tab2" className="outline-none">
+                      <MarkdownSplitPane
+                        value={tab2}
+                        onChange={setTab2}
+                        textareaRef={pocusTextareaRef2}
+                        placeholder={"# Techniek\n\nProbe-positionering, acquisitie en video's..."}
+                      />
+                    </TabsContent>
+                    <TabsContent value="tab3" className="outline-none">
+                      <MarkdownSplitPane
+                        value={tab3}
+                        onChange={setTab3}
+                        textareaRef={pocusTextareaRef3}
+                        placeholder={"# Interpretatie\n\nBevindingen en algoritmes..."}
+                      />
+                    </TabsContent>
+                  </Tabs>
                 </>
               )}
             </CardContent>

--- a/client/src/pages/pocus-detail.tsx
+++ b/client/src/pages/pocus-detail.tsx
@@ -55,8 +55,8 @@ export default function PocusDetail() {
 
         <Tabs defaultValue="indicaties" className="w-full">
           <TabsList className="grid w-full grid-cols-3 bg-slate-100 rounded-2xl p-1 mb-8">
-            <TabsTrigger value="indicaties" className="rounded-xl font-black text-[10px] uppercase">Algemeen</TabsTrigger>
-            <TabsTrigger value="techniek" className="rounded-xl font-black text-[10px] uppercase">Acquisitie</TabsTrigger>
+            <TabsTrigger value="indicaties" className="rounded-xl font-black text-[10px] uppercase">Indicaties</TabsTrigger>
+            <TabsTrigger value="techniek" className="rounded-xl font-black text-[10px] uppercase">Techniek</TabsTrigger>
             <TabsTrigger value="interpretatie" className="rounded-xl font-black text-[10px] uppercase">Interpretatie</TabsTrigger>
           </TabsList>
           

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,6 @@
         "react-hook-form": "^7.66.0",
         "react-markdown": "^9.0.0",
         "react-medium-image-zoom": "^5.2.14",
-        "react-quill-new": "^3.3.3",
         "react-resizable-panels": "^2.1.9",
         "recharts": "^2.15.4",
         "rehype-katex": "^7.0.0",
@@ -9281,12 +9280,6 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
-    "node_modules/fast-diff": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
-      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
-      "license": "Apache-2.0"
-    },
     "node_modules/fast-equals": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
@@ -11469,18 +11462,6 @@
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "license": "MIT"
     },
-    "node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
-      "license": "MIT"
-    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -11497,13 +11478,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
       "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
-      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -12943,12 +12917,6 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "license": "BlueOak-1.0.0"
     },
-    "node_modules/parchment": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/parchment/-/parchment-3.0.0.tgz",
-      "integrity": "sha512-HUrJFQ/StvgmXRcQ1ftY6VEZUq3jA2t9ncFN4F84J/vN0/FPpQF+8FKXb3l6fLces6q0uOHj6NJn+2xvZnxO6A==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -13465,41 +13433,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/quill": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/quill/-/quill-2.0.3.tgz",
-      "integrity": "sha512-xEYQBqfYx/sfb33VJiKnSJp8ehloavImQ2A6564GAbqG55PGw1dAWUn1MUbQB62t0azawUS2CZZhWCjO8gRvTw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "eventemitter3": "^5.0.1",
-        "lodash-es": "^4.17.21",
-        "parchment": "^3.0.0",
-        "quill-delta": "^5.1.0"
-      },
-      "engines": {
-        "npm": ">=8.2.3"
-      }
-    },
-    "node_modules/quill-delta": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-5.1.0.tgz",
-      "integrity": "sha512-X74oCeRI4/p0ucjb5Ma8adTXd9Scumz367kkMK5V/IatcX6A0vlgLgKbzXWy5nZmCGeNJm2oQX0d2Eqj+ZIlCA==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-diff": "^1.3.0",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.isequal": "^4.5.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/quill/node_modules/eventemitter3": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
-      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
-      "license": "MIT"
-    },
     "node_modules/random-bytes": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
@@ -13664,21 +13597,6 @@
       "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.2.tgz",
       "integrity": "sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug==",
       "license": "MIT"
-    },
-    "node_modules/react-quill-new": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/react-quill-new/-/react-quill-new-3.8.3.tgz",
-      "integrity": "sha512-c96PYqFTo0pI4R3e79B3rH9LUIce1kIQbmTBu/imJQZk8305ogyLyBqKKjG2UoInDlquXqePSzmBo2aVia3ttw==",
-      "license": "MIT",
-      "dependencies": {
-        "lodash-es": "^4.17.21",
-        "quill": "~2.0.3"
-      },
-      "peerDependencies": {
-        "quill-delta": "^5.1.0",
-        "react": "^16 || ^17 || ^18 || ^19",
-        "react-dom": "^16 || ^17 || ^18 || ^19"
-      }
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "react-hook-form": "^7.66.0",
     "react-markdown": "^9.0.0",
     "react-medium-image-zoom": "^5.2.14",
-    "react-quill-new": "^3.3.3",
     "react-resizable-panels": "^2.1.9",
     "recharts": "^2.15.4",
     "rehype-katex": "^7.0.0",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Doel
POCUS op dezelfde manier beheren als Blocks via Supabase CMS.

## Wijzigingen
- POCUS-editor: Quill HTML vervangen door **Markdown split-pane** (ruw + live preview)
- Drie tabs: **Indicaties**, **Techniek**, **Interpretatie**
- Uploadbalk met **Video**, **Afbeelding** en **PDF** (cursor-insertie per actieve tab)
- Detailpagina: tablabels gelijkgetrokken met editor
- Ongebruikte `react-quill-new` dependency verwijderd
- Optioneel: `POCUS_SCHEMA.sql` voor Supabase-setup

## Gebruik
1. `/admin?type=pocus` voor nieuwe scan
2. `/admin?type=pocus&id=<uuid>` voor bewerken
3. Media uploaden via knoppen boven de tabs

## Test
- `npm run check` en `npm run build` slagen
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-413fbd75-2d83-4cae-a2c5-111222165a20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-413fbd75-2d83-4cae-a2c5-111222165a20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

